### PR TITLE
Separate modal route

### DIFF
--- a/TCMSApp/src/client/app/defects/add-defect.controller.js
+++ b/TCMSApp/src/client/app/defects/add-defect.controller.js
@@ -1,0 +1,63 @@
+/**
+ * @ngdoc controller
+ * @memberOf app.defects
+ * @name addDefectController
+ * Creates for view, where the modal will be open
+ */
+
+(function() {
+    "use strict";
+
+    angular
+        .module("app.defects")
+        .controller("AddDefectController", AddDefectController);
+
+    AddDefectController.$inject = ["$uibModal", "$state", "$scope", "$stateParams", "$rootScope", "logger"];
+
+    function AddDefectController($uibModal, $state, $scope, $stateParams, $rootScope, logger) {
+
+        var vm = this;
+        vm.open = open;
+
+        vm.open();
+
+        /**
+         * Opens "Add defect" modal window
+         * @memberOf addDefectController
+         */
+        function open() {
+            if( !$stateParams.previousState ) {
+                $state.go("dashboard");
+            } else {
+                $uibModal.open({
+                    templateUrl: 'addDefectModalTemplate.html',
+                    controller: function ($uibModalInstance, $state, $scope, $rootScope, logger) {
+                        var vmDefectModal = this;
+                        var allowStateChange = false;
+
+                        if($stateParams.run) {
+                            vmDefectModal.run = $stateParams.run.info;
+                        }
+
+                        vmDefectModal.cancel = function () {
+                            allowStateChange = true;
+
+                            $uibModalInstance.dismiss('cancel');
+                            $state.go($stateParams.previousState);
+                        };
+
+                        // prevent state changing without interraction with modal controlls
+                        $scope.$on("$stateChangeStart", function(event, toState, toParams, fromState, fromParams) {
+                            if ( !allowStateChange ) {
+                                logger.warning("Please Save or Cancel this dialog!", "", "Save or Cancel");
+                                event.preventDefault();
+                            }
+                        })
+                    },
+                    controllerAs: 'vmDefectModal',
+                    backdrop: "static"
+                });
+            }
+        };
+    }
+})();

--- a/TCMSApp/src/client/app/defects/add-defect.template.html
+++ b/TCMSApp/src/client/app/defects/add-defect.template.html
@@ -1,0 +1,51 @@
+<div>
+    <script type="text/ng-template" id="addDefectModalTemplate.html">
+        <div class="modal-header">
+            <button type="button" class="close" ng-click="vmDefectModal.cancel()"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Add defect</h4>
+        </div>
+        <div class="modal-body">
+            <div class="row">
+            <div class="form-group col-md-9">
+            <label for="errorname">Bugs Name</label>
+        <input type="text" class="form-control" id="errorname" placeholder="ErrorName". ng-value="vmDefectModal.run">
+            </div>
+            <div class="form-group col-md-3">
+            <label>Priority:</label>
+        <select class="form-control">
+            <option>Critical</option>
+            <option>High</option>
+            <option>Normal</option>
+            <option>Low</option>
+            </select>
+            </div>
+            </div>
+            <div class="row">
+            <div class="form-group col-md-6">
+            <label for="whoFind">Who Find:</label>
+        <input type="text" class="form-control" id="whoFind" placeholder="Who Find">
+            </div>
+            <div class="form-group col-md-6">
+            <label for="assignedTo">Assigned to:</label>
+        <input type="text" class="form-control" id="assignedTo" placeholder="Assigned to">
+            </div>
+            </div>
+            <div class="form-group">
+            <label for="description">Description:</label>
+        <textarea class="form-control" id="description" rows="3" placeholder="Description"></textarea>
+
+            </div>
+            <div class="form-group" enctype="multipart/form-data" method="post">
+            <input type="file" value="Attach file" id="choose-file">
+            </div>
+            <div class="form-group">
+            <label for="testCase">Steps To Reproduce:</label>
+        <textarea class="form-control" id="testCase" rows="2" placeholder="TestCase"></textarea>
+            </div>
+            </div>
+            <div class="modal-footer">
+            <button type="button" class="btn btn-default" ng-click="vmDefectModal.cancel()">Cancel</button>
+            <button type="button" class="btn btn-primary" ng-click="vmDefectModal.cancel()">Post</button>
+            </div>
+    </script>
+</div>

--- a/TCMSApp/src/client/app/defects/defects.controller.js
+++ b/TCMSApp/src/client/app/defects/defects.controller.js
@@ -5,9 +5,9 @@
         .module('app.defects')
         .controller('DefectsController', DefectsController);
 
-    DefectsController.$inject = ['logger', '$uibModal', 'getDefects'];
+    DefectsController.$inject = ['logger', '$uibModal', 'getDefects', '$state'];
     /* @ngInject */
-    function DefectsController(logger, $uibModal, getDefects) {
+    function DefectsController(logger, $uibModal, getDefects, $state) {
         var vm = this;
         vm.arrayDefects = getDefects.fakeDefect(10);
         vm.toogledAll = false;
@@ -21,18 +21,7 @@
             vm.currentDefect == null;
         }
 
-        vm.open = function () {
-            $uibModal.open({
-                templateUrl: 'addBugs.html',
-                controller: function ($uibModalInstance) {
-                    var vmDefectModal = this;
-                    vmDefectModal.cancel = function () {
-                        $uibModalInstance.dismiss('cancel');
-                    };
-                },
-                controllerAs: 'vmDefectModal'
-            });
-        };
+        vm.previousState = $state.$current.name;
 
         activate();
 

--- a/TCMSApp/src/client/app/defects/defects.html
+++ b/TCMSApp/src/client/app/defects/defects.html
@@ -27,7 +27,7 @@
                     </div>
                 </form>
                 <h1>Defects
-                    <button type="button" class="btn btn-success btn-xs" ng-click="vmDefects.open()">Add Defect</button>
+                    <button type="button" class="btn btn-success btn-xs" ui-sref="add-defect({ previousState: vmDefects.previousState })">Add Defect</button>
                 </h1>
 
             </div>
@@ -128,54 +128,7 @@
             </div>
         </div>
     </div>
+
+    <!-- view for add defect modal-->
+    <div ui-view=""></div>
 </section>
-
-<script type="text/ng-template" id="addBugs.html">
-    <div class="modal-header">
-        <button type="button" class="close" ng-click="vmDefectModal.cancel()"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title">Add defect</h4>
-    </div>
-    <div class="modal-body">
-        <div class="row">
-            <div class="form-group col-md-9">
-                <label for="errorname">Bugs Name</label>
-                <input type="text" class="form-control" id="errorname" placeholder="ErrorName">
-            </div>
-            <div class="form-group col-md-3">
-                <label>Priority:</label>
-                <select class="form-control">
-                    <option>Critical</option>
-                    <option>High</option>
-                    <option>Normal</option>
-                    <option>Low</option>
-                </select>
-            </div>
-        </div>
-        <div class="row">
-            <div class="form-group col-md-6">
-                <label for="whoFind">Who Find:</label>
-                <input type="text" class="form-control" id="whoFind" placeholder="Who Find">
-            </div>
-            <div class="form-group col-md-6">
-                <label for="assignedTo">Assigned to:</label>
-                <input type="text" class="form-control" id="assignedTo" placeholder="Assigned to">
-            </div>
-        </div>
-        <div class="form-group">
-            <label for="description">Description:</label>
-            <textarea class="form-control" id="description" rows="3" placeholder="Description"></textarea>
-
-        </div>
-        <div class="form-group" enctype="multipart/form-data" method="post">
-           <input type="file" value="Attach file" id="choose-file">
-        </div>
-        <div class="form-group">
-            <label for="testCase">Steps To Reproduce:</label>
-            <textarea class="form-control" id="testCase" rows="2" placeholder="TestCase"></textarea>
-        </div>
-    </div>
-    <div class="modal-footer">
-        <button type="button" class="btn btn-default" ng-click="vmDefectModal.cancel()">Cancel</button>
-        <button type="button" class="btn btn-primary">Post</button>
-    </div>
-</script>

--- a/TCMSApp/src/client/app/defects/defects.route.js
+++ b/TCMSApp/src/client/app/defects/defects.route.js
@@ -26,6 +26,22 @@
                         content: '<i class="fa fa-lock"></i> Defects'
                     }
                 }
+            },
+            // new nested route and controller for add defect modal window
+            {
+                state: 'add-defect',
+                config: {
+                    url: '/create',
+                    templateUrl: 'app/defects/add-defect.template.html',
+                    controller: 'AddDefectController',
+                    controllerAs: 'vmAddDefect',
+                    title: 'Defect',
+                    params: {
+                        previousState: null,
+                        run: null
+                    },
+                    parent: "defects"
+                }
             }
         ];
     }

--- a/TCMSApp/src/client/app/runs/run-execute.html
+++ b/TCMSApp/src/client/app/runs/run-execute.html
@@ -132,7 +132,7 @@
                                                 <div class="btn-group text-center">
                                                     <label class="btn btn-success" ng-model="radioModel" uib-btn-radio="'Left'">Success</label>
                                                     <label class="btn btn-default" ng-model="radioModel" uib-btn-radio="'Middle'">Blocked</label>
-                                                    <label class="btn btn-danger" ng-model="radioModel" uib-btn-radio="'Right'">Failed</label>
+                                                    <label class="btn btn-danger" ng-model="radioModel" ui-sref="generate-defect({ run: vmRunExecute.run, previousState: vmRunExecute.previousState })" uib-btn-radio="'Right'">Failed</label>
                                                 </div>
                                             </div>
                                         </div>
@@ -171,6 +171,8 @@
             </div>
         </div>
 
+        <!-- view for add defect modal-->
+        <div ui-view=""></div>
     </div>
 </div>
 

--- a/TCMSApp/src/client/app/runs/run.controller.js
+++ b/TCMSApp/src/client/app/runs/run.controller.js
@@ -12,15 +12,27 @@
         .module('app.runs')
         .controller('RunController', RunController);
 
-    RunController.$inject = [];
+    RunController.$inject = ["logger", "$state"];
 
-    function RunController() {
-        /**
-         * Bind view model as "vm"
-         * @memberOf runController
-         * @type {RunController}
-         */
+    function RunController(logger, $state) {
+
         var vm = this;
+
+        // object that contains details of current run
+        vm.run = {
+            runId: 1,
+            info: "info about current run"
+        };
+
+        // name of current state, that will be sent as previous state for "Add defect" modal window
+        // should be used by any controller that uses "Add defect" modal
+        vm.previousState = $state.$current.name;
+
+        activate();
+
+        function activate() {
+            logger.info("Activated run execute view!");
+        }
 
     }
 })();

--- a/TCMSApp/src/client/app/runs/runs.route.js
+++ b/TCMSApp/src/client/app/runs/runs.route.js
@@ -33,13 +33,25 @@
                 config: {
                     url: '/runs/execute',
                     templateUrl: 'app/runs/run-execute.html',
-                    controller: 'RunsController',
-                    controllerAs: 'vm',
-                    title: 'Create Test Case',
-                    settings: {
-                        nav: 5,
-                        content: '<i class="fa fa-team"></i> Execute Run'
-                    }
+                    controller: 'RunController',
+                    controllerAs: 'vmRunExecute',
+                    title: 'Execute run'
+                }
+            },
+            // new nested route and controller for addBug modal window
+            {
+                state: 'generate-defect',
+                config: {
+                    url: '/create-defect',
+                    templateUrl: 'app/defects/add-defect.template.html',
+                    controller: 'AddDefectController',
+                    controllerAs: 'vmAddDefect',
+                    title: 'Defect',
+                    params: {
+                        previousState: null,
+                        run: null
+                    },
+                    parent: "run-execute"
                 }
             }
         ];

--- a/TCMSApp/src/client/app/runs/runs.route.js
+++ b/TCMSApp/src/client/app/runs/runs.route.js
@@ -38,7 +38,7 @@
                     title: 'Execute run'
                 }
             },
-            // new nested route and controller for addBug modal window
+            // new nested route and controller for addDefect modal window
             {
                 state: 'generate-defect',
                 config: {

--- a/TCMSApp/src/client/index.html
+++ b/TCMSApp/src/client/index.html
@@ -86,6 +86,7 @@
     <script src="/src/client/app/core/dataservice.js"></script>
     <script src="/src/client/app/dashboard/dashboard.controller.js"></script>
     <script src="/src/client/app/dashboard/dashboard.route.js"></script>
+    <script src="/src/client/app/defects/add-defect.controller.js"></script>
     <script src="/src/client/app/defects/defects.controller.js"></script>
     <script src="/src/client/app/defects/defects.route.js"></script>
     <script src="/src/client/app/layout/ht-sidebar.directive.js"></script>


### PR DESCRIPTION
There are two places where we can call modal window for "add bug" functionality: /defects/list (on create defect); runs/execute (on step fails). Then we go to /defects/bug route. 

Our previous state saved on $rootScope.previousState field (see shell.controller). If we cancel the modal we'll go to app previous state.

If after page reloading we stay on /defects/bug route (modal), the application will redirect us to /dashboard because we havn't previous state on $rootScope and I think there is no reason to create bug from nothing.

PS: all code in the second commit =). First commit is merely first commit.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-167839418%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-167852958%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-167891112%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-168335635%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-168350055%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-168350096%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-169120014%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-169309176%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-169450395%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-169669350%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-170398739%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/100%23issuecomment-167839418%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20there%20something%20in%20ui-routing%20that%20can%20be%20used%20instead%20%24rootScope.previousState%3F%20There%20should%20be%20something%21%21%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-12-29T17%3A39%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20really%20nothing%20in%20ui-routing.%20Will%20we%20send%20some%20data%20over%20params%20in%20ui-route%3F%20%28for%20example%20some%20data%20with%20test%20steps%20to%20pass%20into%20steps%20to%20reproduce%20section%29.%22%2C%20%22created_at%22%3A%20%222015-12-29T18%3A55%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok.%20I%20think%20we%27ll%20send%20only%20id%20of%20current%20run%20%28runs/execute/%3Aid%29.%20This%20helps%20us%20to%20get%20info%20about%20run%20in%20modal%20through%20request%20to%20DB.%20What%20do%20you%20think%20about%20this%3F%5Cr%5CnI%27ll%20release%20this%20way%20of%20solving%20problem.%20%5Cr%5CnOk%3F%22%2C%20%22created_at%22%3A%20%222015-12-29T22%3A28%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10531174%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ValeriiMal%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20I%20have%20done%3A%5Cr%5Cn-%20previousState%20send%20through%20the%20%24stateParams%20to%20AddBugsController%20in%20params%20custom%20object%20%21%21%21%20now%20we%20don%27t%20need%20to%20use%20%24rootScope%29%5Cr%5Cn-%20now%20we%20can%20set%20custom%20params%20object%20%28for%20example%20in%20code%3A%20params%3A%20%7B%20previousState%3A%20null%2C%20run%3A%20%7B%20runId%3A%20null%2C%20info%3A%20null%20%7D%2C%20%7D%20%29%2C%20see%20route%20for%20defects%2C%20and%20set%20up%20this%20object%20directly%20in%20the%20controller%20of%20current%20run%20view%20or%20defects%20view.%20Then%20it%20is%20so%20simple%20to%20set%20this%20object%20as%20ui-sref%3D%5C%22addBugs%28%20%7B%20params%20object%20%7D%20%29%5C%22%20as%20you%20can%20see%20in%20defects%20view%20or%20run-execute%20view.%5Cr%5Cn-%20I%20think%20that%20wee%20need%20to%20use%20separate%20controller%20for%20run-execute%20view%2C%20so%20I%20have%20done%20some%20little%20changes%20to%20runs.route.js%20so%20now%20we%20use%20run.controller.js%20again%29%22%2C%20%22created_at%22%3A%20%222016-01-01T20%3A19%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10531174%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ValeriiMal%22%7D%7D%2C%20%7B%22body%22%3A%20%22GREAT%21%20you%27ve%20understood%20my%20New%20Year%20comments.%5Cr%5CnBut%20can%20you%20please%20leave%20only%20files%20that%20are%20implementing%20separate%20route%20for%20the%20modal%20%28I%20don%27t%20believe%20that%20you%20need%2056%20files%20for%20that%20%3A%29%20%29%22%2C%20%22created_at%22%3A%20%222016-01-01T23%3A22%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22One%20bug%3A%20try%20to%20hit%20browser%27s%20%5C%22back%5C%22%20button%20in%20this%20modal%20view.%20everything%20will%20fail%22%2C%20%22created_at%22%3A%20%222016-01-01T23%3A23%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fix%20this%20bug%20by%20allow%20state%20changing%20only%20from%20modal.%20See%20%5C%22add-bugs.controller%20-%3E%20uibModal%20controller%20-%3E%20%24scope.%24on%28%5C%22%24stateChangeStart%5C%22%2C%20.....%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-01-05T20%3A20%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10531174%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ValeriiMal%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20understood%20that%20here%20we%20have%202%20problems%20that%20I%20don%27t%20know%20how%20to%20solve.%5Cr%5Cn1.%20If%20we%20publish%20bug%20from%20the%20test%20run%20page%20it%20is%20%2Acritical%2A%20to%20come%20back%20to%20the%20test%20run%20page%20with%20the%20same%20state%20%28keep%20all%20test%20steps%20information%29.%20it%20shall%20not%20be%20so%20now.%5Cr%5Cn2.%20Now%20this%20is%20actually%20not%20a%20modal%20%28nothing%20on%20background%2C%20only%20navbar%29%5Cr%5Cn%5Cr%5Cnmaybe%20we%20should%20use%20%5Bsomething%20like%20this%5D%20%28https%3A//lingohub.com/blog/2015/06/bootstrap-modal-window-custom-url-angularjs/%29.%20But%20then%20we%20might%20create%202%20routes%3A%5Cr%5Cn-%20defects/cerate%5Cr%5Cn-%20runs/execute/create-defect%5Cr%5Cn%5Cr%5Cnwhat%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222016-01-06T12%3A07%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20know%29%20I%27m%20thought%20about%20page%20for%20new%20defect%20earlier%20and%20I%20think%20that%20this%20is%20no%20bad%20idea%20because%20step%20story%20produce%20can%20be%20so%20long%20for%20modal%20window%20format%20and%20there%20can%20be%20additional%20features%20as%20you%20wrote%20above.%20I%20didn%5C%5Ct%20want%20to%20propose%20that%20because%20this%20is%20interesting%20task%20for%20me%20with%20separate%20routes%20for%20modal%20%3D%29.%20%5Cr%5CnI%20will%20not%20be%20sad%20because%20if%20this%20but%20this%20modal%20is%20Aleksandra%27s%20work%20...%20%5Cr%5Cn%5Cr%5CnI%20think%20that%20we%20should%20use%20separate%20page%20but%20I%20can%20try%20for%20a%20two%20days%20finish%20task%20with%20modal%20to%20see%20how%20it%20will%20looks%20like.%5Cr%5CnYour%20word%20%3D%29%22%2C%20%22created_at%22%3A%20%222016-01-06T20%3A22%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10531174%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ValeriiMal%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok.%20two%20days%20is%20good.%20we%20can%20do%20that.%5Cr%5Cn%5Cr%5Cnso%20it%20is%20your%20turn%20to%20squash%20all%20you%20can%20from%20the%20modal.%22%2C%20%22created_at%22%3A%20%222016-01-07T13%3A52%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20only%20create%20two%20child%20states%20from%20defects/list%20and%20runs/execute%20routes%20relatively%20from%20defects.route.js%20and%20runs.route.js.%20When%20I%20return%20to%20parent%20state%20%60runs/execute%60%20from%20child%22%2C%20%22created_at%22%3A%20%222016-01-10T22%3A12%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10531174%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ValeriiMal%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/100#issuecomment-167839418'>General Comment</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> Is there something in ui-routing that can be used instead $rootScope.previousState? There should be something!! :)
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> Hm, really nothing in ui-routing. Will we send some data over params in ui-route? (for example some data with test steps to pass into steps to reproduce section).
- <a href='https://github.com/ValeriiMal'><img border=0 src='https://avatars.githubusercontent.com/u/10531174?v=3' height=16 width=16'></a> Ok. I think we'll send only id of current run (runs/execute/:id). This helps us to get info about run in modal through request to DB. What do you think about this?
I'll release this way of solving problem.
Ok?
- <a href='https://github.com/ValeriiMal'><img border=0 src='https://avatars.githubusercontent.com/u/10531174?v=3' height=16 width=16'></a> What I have done:
- previousState send through the $stateParams to AddBugsController in params custom object !!! now we don't need to use $rootScope)
- now we can set custom params object (for example in code: params: { previousState: null, run: { runId: null, info: null }, } ), see route for defects, and set up this object directly in the controller of current run view or defects view. Then it is so simple to set this object as ui-sref="addBugs( { params object } )" as you can see in defects view or run-execute view.
- I think that wee need to use separate controller for run-execute view, so I have done some little changes to runs.route.js so now we use run.controller.js again)
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> GREAT! you've understood my New Year comments.
But can you please leave only files that are implementing separate route for the modal (I don't believe that you need 56 files for that :) )
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> One bug: try to hit browser's "back" button in this modal view. everything will fail
- <a href='https://github.com/ValeriiMal'><img border=0 src='https://avatars.githubusercontent.com/u/10531174?v=3' height=16 width=16'></a> Fix this bug by allow state changing only from modal. See "add-bugs.controller -> uibModal controller -> $scope.$on("$stateChangeStart", .....)
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> I've understood that here we have 2 problems that I don't know how to solve.
1. If we publish bug from the test run page it is *critical* to come back to the test run page with the same state (keep all test steps information). it shall not be so now.
2. Now this is actually not a modal (nothing on background, only navbar)
maybe we should use [something like this] (https://lingohub.com/blog/2015/06/bootstrap-modal-window-custom-url-angularjs/). But then we might create 2 routes:
- defects/cerate
- runs/execute/create-defect
what do you think?
- <a href='https://github.com/ValeriiMal'><img border=0 src='https://avatars.githubusercontent.com/u/10531174?v=3' height=16 width=16'></a> You know) I'm thought about page for new defect earlier and I think that this is no bad idea because step story produce can be so long for modal window format and there can be additional features as you wrote above. I didn\t want to propose that because this is interesting task for me with separate routes for modal =).
I will not be sad because if this but this modal is Aleksandra's work ...
I think that we should use separate page but I can try for a two days finish task with modal to see how it will looks like.
Your word =)
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> ok. two days is good. we can do that.
so it is your turn to squash all you can from the modal.
- <a href='https://github.com/ValeriiMal'><img border=0 src='https://avatars.githubusercontent.com/u/10531174?v=3' height=16 width=16'></a> I'm only create two child states from defects/list and runs/execute routes relatively from defects.route.js and runs.route.js. When I return to parent state `runs/execute` from child


<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/100?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/100?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-012/pull/100'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>