### PR TITLE
Changed some code in the models files: added enum validators…and more

### DIFF
--- a/TCMSApp/src/server/model/mschemas/defect.js
+++ b/TCMSApp/src/server/model/mschemas/defect.js
@@ -6,19 +6,14 @@ var Schema = mongoose.Schema;
     //define schema
     var defectSchema = new Schema({
         randomId: Number,
-        name: {type: String, required: true},
+        name: {type: String, required: true, unique: true},
         whoFind: String,
         assignedTo: String,
         dateOfDefectCreation: Date,
         priority: {
             type: String,
             required: true,
-            validate: {
-                validator: function(v) {
-                    return /critical|high|normal|low/i.tests()
-                },
-                message: '{Value} is not allowed'
-            }
+            enum: ['critical', 'low', 'high', 'normal']
         },
         description: {type: String, required: true},
         stepsToReproduce: [String],

--- a/TCMSApp/src/server/model/mschemas/run.js
+++ b/TCMSApp/src/server/model/mschemas/run.js
@@ -28,7 +28,28 @@ var Schema = mongoose.Schema;
             enum: ['passed', 'executing', 'failed', 'none'],
             default: 'none'
         },
-        tests: [mongoose.Schema.Types.ObjectId]
+        tests: [{
+            testName: {type: String, required: true},
+            testDescription: {type: String, required: true},
+            suiteId: mongoose.Schema.Types.ObjectId,
+            automated: Boolean,
+            preConditions: {type: String, required: true},
+            steps: [{
+                stepNumber: Number,
+                stepDescription: {type: String, required: true},
+                expectedResult: {type: String, required: true},
+                status: {
+                    type: String,
+                    enum: ['passed', 'blocked', 'failed', 'none'],
+                    default: 'none'
+                }
+            }],
+            status: {
+                type: String,
+                enum: ['passed', 'executing', 'failed', 'none'],
+                default: 'none'
+            }
+        }]
     });
     var run = mongoose.model('Run',runSchema);
 module.exports = run;

--- a/TCMSApp/src/server/model/mschemas/run.js
+++ b/TCMSApp/src/server/model/mschemas/run.js
@@ -25,45 +25,10 @@ var Schema = mongoose.Schema;
         envFull: {},
         status: {
             type: String,
-            validate: {
-                validator: function (v) {
-                    return /passed|executing|failed/.test(v);
-                },
-                message: '{VALUE} is not valid status!'
-            },
-            default: 'executing'
+            enum: ['passed', 'executing', 'failed', 'none'],
+            default: 'none'
         },
-        //the
-        tests: [{
-            testName: {type: String, required: true},
-            testDescription: {type: String, required: true},
-            automated: Boolean,
-            preConditions: {type: String, required: true},
-            steps: [{
-                stepNumber: Number,
-                stepDescription: {type: String, required: true},
-                expectedResult: {type: String, required: true},
-
-                status: {
-                    type: String,
-                    validate: {
-                        validator: function (v) {
-                            return /passed, blocked, failed/.test(v);
-                        },
-                        message: '{VALUE} is not valid status!'
-                    }
-                }
-            }],
-            status: {
-                type: String,
-                validate: {
-                    validator: function (v) {
-                        return /passed|executing|failed/.test(v);
-                    },
-                    message: '{VALUE} is not valid status!'
-                }
-            }
-        }]
+        tests: [mongoose.Schema.Types.ObjectId]
     });
     var run = mongoose.model('Run',runSchema);
 module.exports = run;

--- a/TCMSApp/src/server/model/mschemas/suite.js
+++ b/TCMSApp/src/server/model/mschemas/suite.js
@@ -13,13 +13,24 @@ var testSuiteSchema = new Schema({
     tests: [{
         testName: {type: String, required: true},
         testDescription: {type: String, required: true},
+        suiteId: mongoose.Schema.Types.ObjectId,
         automated: Boolean,
         preConditions: {type: String, required: true},
         steps: [{
             stepNumber: Number,
             stepDescription: {type: String, required: true},
-            expectedResult: {type: String, required: true}
-        }]
+            expectedResult: {type: String, required: true},
+            status: {
+                type: String,
+                enum: ['passed', 'blocked', 'failed', 'none'],
+                default: 'none'
+            }
+        }],
+        status: {
+            type: String,
+            enum: ['passed', 'executing', 'failed', 'none'],
+            default: 'none'
+        }
     }]
 });
 var testSuite = mongoose.model('Suite', testSuiteSchema);

--- a/TCMSApp/src/server/model/mschemas/user.js
+++ b/TCMSApp/src/server/model/mschemas/user.js
@@ -8,7 +8,7 @@ var Schema = mongoose.Schema;
     var userSchema = new Schema({
         firstName: {type: String, required: true},
         lastName: {type: String, required: true},
-        userName: {type: String, required: true},
+        userName: {type: String, required: true, unique: true},
         password: {type: String, required: true},
         email: {
             type: String,
@@ -39,15 +39,11 @@ var Schema = mongoose.Schema;
         role: {
             type: String,
             required: true,
-            validate: {
-                validator: function (v) {
-                    return /administrator|tester/i.test(v);
-                },
-                message: '{VALUE} is not a valid user role'
-            }
+            enum: ['tester', 'administrator']
         }
 
     });
+
     var user = mongoose.model('User', userSchema);
 module.exports = user;
 


### PR DESCRIPTION
Check out this version
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/123%23discussion_r49664716%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/123%23issuecomment-171600627%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/123%23discussion_r49801156%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/123%23issuecomment-171600627%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK.%20You%27ve%20got%20a%20point.%22%2C%20%22created_at%22%3A%20%222016-01-14T10%3A31%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16047980%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OlehKSS%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206095da98a85bea68b8963eeacb60210542683184%20TCMSApp/src/server/model/mschemas/run.js%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/123%23discussion_r49664716%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20we%20should%20leave%20the%20tests%20here.%5Cr%5Cnwhy%3F%5Cr%5Cn1.%20we%20need%20to%20store%20information%20on%20failing/passing%20steps.%5Cr%5Cn2.%20test%20case%20can%20be%20changed%20%28but%20we%20need%20to%20store%20in%20the%20test%20run%20the%20state%20of%20test%20case%20for%20the%20moment%20of%20the%20test%20run%21%29%22%2C%20%22created_at%22%3A%20%222016-01-13T22%3A59%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/server/model/mschemas/run.js%3AL25-35%22%7D%2C%20%22Pull%209d229e895022f207d0aa341a56c79c52e9fac0d5%20TCMSApp/src/server/model/mschemas/suite.js%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/123%23discussion_r49801156%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ohh%2C%20suites%20have%20no%20statuses.%20only%20runs.%5Cr%5Cn%5Cr%5Cnsuites/tests/steps%20are%20scenarios.%20%5Cr%5Cnruns%20can%20have%20statuses.%5Cr%5Cn%5Cr%5CnBut%21%5Cr%5Cnwe%20might%20have%20an%20idea%20to%20connect%20test%20steps%20with%20the%20result%20of%20an%20execution%20of%20all%20test%20runs%20made%20on%20the%20particular%20test.%5Cr%5CnIt%20can%20be%20done%20by%20keeping%20the%20reference%20to%20array%20of%20test%20runs%20from%20the%20test%20objects%21%20This%20fact%20can%20be%20discussed%20%22%2C%20%22created_at%22%3A%20%222016-01-14T23%3A21%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/server/model/mschemas/suite.js%3AL13-37%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 6095da98a85bea68b8963eeacb60210542683184 TCMSApp/src/server/model/mschemas/run.js 45'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/123#discussion_r49664716'>File: TCMSApp/src/server/model/mschemas/run.js:L25-35</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> I think we should leave the tests here.
why?
1. we need to store information on failing/passing steps.
2. test case can be changed (but we need to store in the test run the state of test case for the moment of the test run!)
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/123#issuecomment-171600627'>General Comment</a></b>
- <a href='https://github.com/OlehKSS'><img border=0 src='https://avatars.githubusercontent.com/u/16047980?v=3' height=16 width=16'></a> OK. You've got a point.
- [ ] <a href='#crh-comment-Pull 9d229e895022f207d0aa341a56c79c52e9fac0d5 TCMSApp/src/server/model/mschemas/suite.js 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/123#discussion_r49801156'>File: TCMSApp/src/server/model/mschemas/suite.js:L13-37</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> ohh, suites have no statuses. only runs.
suites/tests/steps are scenarios.
runs can have statuses.
But!
we might have an idea to connect test steps with the result of an execution of all test runs made on the particular test.
It can be done by keeping the reference to array of test runs from the test objects! This fact can be discussed


<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/123?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/123?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-012/pull/123'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>