### PR TITLE
Gitignore mongo fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/Release
 node_modules
 bower_components
 .idea
+TCMSApp/src/mongodb/

--- a/TCMSApp/.gitignore
+++ b/TCMSApp/.gitignore
@@ -8,4 +8,4 @@ bower_components/
 .idea/*
 build/
 jsdoc/
-mongodb/
+src/mongodb/

--- a/TCMSApp/.gitignore
+++ b/TCMSApp/.gitignore
@@ -9,3 +9,4 @@ bower_components/
 build/
 jsdoc/
 src/mongodb/
+


### PR DESCRIPTION
I have pulled latest master and `src/mongodb/data` didn't work for me
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/127?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-012/pull/127'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>