### PR TITLE
Runs connected to api and id added, some view enhancement

### DIFF
--- a/TCMSApp/bower.json
+++ b/TCMSApp/bower.json
@@ -29,7 +29,7 @@
     "bootstrap-css-only": "~3.3.5",
     "faker": "Faker#~3.0.1",
     "angular-messages": "~1.4.8",
-	"angular-resource": "~1.4.8" 
+	"angular-resource": "~1.4.8"
   },
   "resolutions": {
     "angular": "1.3.17"

--- a/TCMSApp/src/client/app/blocks/fakers/fake-runs.factory.js
+++ b/TCMSApp/src/client/app/blocks/fakers/fake-runs.factory.js
@@ -23,7 +23,7 @@
          * Generate specified number of fake run objects
          * ```
          * {
-          *    "_id": "int",
+          *
           *    "previousRunId": "int",
           *    "date": "date",
           *    "build": "string",
@@ -31,7 +31,7 @@
           *    "envFull": "string",
           *    "status": "string: ['passed', 'failed', 'not run']",
           *    "tests": [{
-          *        "_id": "int",
+          *
           *        "status": "string: ['passed', 'failed', 'not run']",
           *        "name": 'string',
           *        "suite": 'string',
@@ -109,7 +109,6 @@
                 while (++i < quantity) {
                     steps = getSteps(faker.random.number({max: stepsMaxCount, min: 1}));
                     var test = {
-                        _id: faker.random.number(1000),
                         status: checkStatus(steps),
                         name: faker.lorem.sentence(2, 3).slice(0, -1),
                         suite: suites[faker.random.number(suites.length - 1)],
@@ -137,13 +136,11 @@
                 };
                 var tests = getTests(faker.random.number({max: testsMaxCount, min: 1}));
                 var run = {
-                    _id: faker.random.number(1000000),
-                    previousRunId: faker.random.number(1000000),
-                    date: faker.date.past(),
+                    dateStart: faker.date.past(),
                     build: faker.random.number(1000),
                     author: {
-                        'first': faker.name.firstName(),
-                        'last': faker.name.lastName()
+                        'firstName': faker.name.firstName(),
+                        'lastName': faker.name.lastName()
                     },
                     envShort: OSShort[env['OS']] + '/' + browsersShort[env['Browser']],
                     envFull: {

--- a/TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js
+++ b/TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js
@@ -5,17 +5,47 @@
         .module('app.runsExec')
         .controller('RunsEditController', RunsEditController);
 
-    RunsEditController.$inject = ['$stateParams', 'logger', 'moment'];
+    RunsEditController.$inject = ['$stateParams', '$state', 'RunsApiService', 'logger', 'moment'];
 
-    function RunsEditController($stateParams) {
+    function RunsEditController($stateParams, $state, RunsApiService) {
         var vm = this;
-        //TODO: change this temporary solution of exchanging run data between edit and run tabs
-        vm.run = JSON.parse(JSON.stringify($stateParams.run));//creating of the deep copy
         vm.addEnvDetail = addEnvDetail;
 
-        function addEnvDetail (param, value) {
+        activate();
 
-            vm.run.envFull[param] = value;
+        function activate() {
+
+            if ($stateParams.run === undefined) {
+                RunsApiService.get({id: $stateParams.id}).$promise.then(processData, processError);
+            }
+            else
+            {
+                processData($stateParams.run);
+            }
+
+        }
+
+        function processData(result) {
+            //TODO: change this temporary solution of exchanging run data between edit and run tabs
+            vm.run = JSON.parse(JSON.stringify(result));//creating of the deep copy
+
+        }
+
+        //we will redirect user to run creation if the db connection fails etc
+        function processError(error) {
+            vm.run = {};//creating of the new test run
+            vm.run.envFull = {};
+
+        }
+
+        function addEnvDetail ($event, param, value) {
+
+            //for 'enter' keyCode = 13 (or 10 in FireFox)
+            if ((($event.keyCode === 13) || ($event.keyCode === 10)) && (param) && (value)) {
+                vm.run.envFull[param] = value;
+                vm.param = undefined;
+                vm.value = undefined;
+            }
 
         }
 

--- a/TCMSApp/src/client/app/runs/runs-exec/runs-edit.html
+++ b/TCMSApp/src/client/app/runs/runs-exec/runs-edit.html
@@ -6,7 +6,8 @@
             <form class="form-inline pull-right">
                 <div class="btn-group">
                     <button type="button" class="btn btn-default tabsSelected" ui-sref="runs-edit()" >Edit</button>
-                    <button type="button" class="btn btn-default tabsNotSelected" ui-sref="runs-execute({run: vmRunsEdit.run})">Run</button>
+                    <button type="button" class="btn btn-default tabsNotSelected"
+                            ui-sref="runs-execute({id: vmRunsExecute.run._id, run: vmRunsEdit.run})">Run</button>
                 </div>
             </form>
 
@@ -24,7 +25,7 @@
                             Short information
                             </div>
                         <div class="panel-body">
-                    <div class="col-md-12">
+                    <div class="form-group col-md-12">
                     <label for="run-name">Name</label>
                     <input type="text" name="" id="run-name" class="form-control"  ng-model="vmRunsEdit.run.name"/>
                     </div>
@@ -54,17 +55,18 @@
                                     </thead>
                                     <tbody>
                                         <tr ng-repeat="(key, value) in vmRunsEdit.run.envFull">
-                                            <td>{{key}}</td>
-                                            <td>{{value}}</td>
+                                            <td><input type="text" ng-model="key" class="tableInput"
+                                                       ng-keypress="vmRunsEdit.addEnvDetail($event,  key, value)"></td>
+                                            <td><input type="text" ng-model="value" class="tableInput"
+                                                       ng-keypress="vmRunsEdit.addEnvDetail($event,  key, value)"></td>
                                         </tr>
-                                        <tr>
-                                            <td><input type="text" ng-model="param"></td>
-                                            <td><input type="text" ng-model="value"></td>
+                                        <tr> <td><input type="text" ng-model=" vmRunsEdit.param" class="tableInput"
+                                                        ng-keypress="vmRunsEdit.addEnvDetail($event,  vmRunsEdit.param,  vmRunsEdit.value)"
+                                                        placeholder="add new parameter here"></td>
+                                            <td><input type="text" ng-model=" vmRunsEdit.value" class="tableInput"
+                                                       ng-keypress="vmRunsEdit.addEnvDetail($event,  vmRunsEdit.param,  vmRunsEdit.value)"
+                                                       placeholder="and its value here"></td>
                                         </tr>
-                                    <tr>
-                                        <td><button type="button" class="btn btn-default btn-xs" ng-click="vmRunsEdit.addEnvDetail(param, value)">Add</button></td>
-                                        <td>&nbsp;</td>
-                                    </tr>
                                     </tbody>
                                 </table>
                             </div>

--- a/TCMSApp/src/client/app/runs/runs-exec/runs-exec.route.js
+++ b/TCMSApp/src/client/app/runs/runs-exec/runs-exec.route.js
@@ -16,15 +16,15 @@
             {
                 state: 'runs-edit',
                 config: {
-                    url: '/runs/edit',
+                    url: '/runs/:id/edit',
                     templateUrl: 'app/runs/runs-exec/runs-edit.html',
                     controller: 'RunsEditController',
                     controllerAs: 'vmRunsEdit',
                     title: 'Edit Test Run',
                     params: {
                         run: {
-                            value: {},
-                            squash: false
+                            value: undefined,
+                            squash: false//the paraneter won't be shown in the url
                         }
                     }
                 }
@@ -32,15 +32,15 @@
             {
                 state: 'runs-execute',
                 config: {
-                    url: '/runs/execute',
+                    url: '/runs/:id/execute',
                     templateUrl: 'app/runs/runs-exec/runs-execute.html',
                     controller: 'RunsExecuteController',
                     controllerAs: 'vmRunsExecute',
                     title: 'Execute Test Run',
                     params: {
                         run: {
-                            value: {},
-                            squash: false
+                            value: undefined,
+                            squash: false//the paraneter won't be shown in the url
                         }
                     }
                 }

--- a/TCMSApp/src/client/app/runs/runs-exec/runs-execute.controller.js
+++ b/TCMSApp/src/client/app/runs/runs-exec/runs-execute.controller.js
@@ -5,17 +5,38 @@
         .module('app.runsExec')
         .controller('RunsExecuteController', RunsExecuteController);
 
-    RunsExecuteController.$inject = ['$stateParams','logger','moment'];
+    RunsExecuteController.$inject = ['$stateParams', '$state', 'logger','moment','RunsApiService'];
 
-    function RunsExecuteController($stateParams) {
+    function RunsExecuteController($stateParams, $state, logger, moment,  RunsApiService) {
 
         var vm = this;
-        //TODO: change this temporary solution of exchanging run data between edit and run tabs
-        vm.run = JSON.parse(JSON.stringify($stateParams.run));//creating of the deep copy
-        vm.progress = getProgress();
-        vm.suites = getSuites();
-        vm.selectedSuite = vm.suites[0];
-        vm.selectedTest = vm.run.tests[0];
+
+        activate();
+
+        function activate() {
+
+            if ($stateParams.run === undefined) {
+                RunsApiService.get({id: $stateParams.id}).$promise.then(processData, processError);
+            }
+            else
+            {
+                processData($stateParams.run);
+            }
+
+        }
+
+        function processError(error) {
+            $state.go('runs/list');
+        }
+
+        function processData(result) {
+            //TODO: change this temporary solution of exchanging run data between edit and run tabs
+            vm.run = JSON.parse(JSON.stringify(result));//creating of the deep copy
+            vm.progress = getProgress();
+            vm.suites = getSuites();
+            vm.selectedSuite = vm.suites[0];
+            vm.selectedTest = vm.run.tests[0];
+        }
 
         function getProgress() {
 

--- a/TCMSApp/src/client/app/runs/runs-exec/runs-execute.html
+++ b/TCMSApp/src/client/app/runs/runs-exec/runs-execute.html
@@ -11,7 +11,8 @@
                     <a class="btn btn-default fa fa-pause"></a>
 
                     <div class="btn-group">
-                        <button type="button" class="btn btn-default tabsNotSelected"  ui-sref="runs-edit({run: vmRunsExecute.run})">
+                        <button type="button" class="btn btn-default tabsNotSelected"
+                                ui-sref="runs-edit({id: vmRunsExecute.run._id, run: vmRunsExecute.run})">
                             Edit</button>
                         <button type="button" class="btn btn-default tabsSelected"  ui-sref="runs-execute()" >Run</button>
                     </div>
@@ -51,11 +52,13 @@
                             </div>
                             <b>Suites&Tests</b>
                             <ul ng-repeat="suite in vmRunsExecute.suites">
-                                <li  ng-click="vmRunsExecute.selectedSuite = vmRunsExecute.suites[$index]" ng-bind="::suite">
+                                <li  ng-click="vmRunsExecute.selectedSuite = vmRunsExecute.suites[$index];
+                                 vmRunsExecute.checkoutAllSteps = false" ng-bind="::suite">
                                 </li>
                                 <div ng-if="vmRunsExecute.selectedSuite === vmRunsExecute.suites[$index]">
                                 <ul ng-repeat="test in vmRunsExecute.run.tests">
-                                    <li  ng-if="vmRunsExecute.selectedSuite === test.suite" ng-bind="::test.name" ng-click="vmRunsExecute.selectedTest = test"></li>
+                                    <li  ng-if="vmRunsExecute.selectedSuite === test.suite" ng-bind="::test.name" ng-click="vmRunsExecute.selectedTest = test;
+                                 vmRunsExecute.checkoutAllSteps = false"></li>
                                 </ul>
                                 </div>
                             </ul>

--- a/TCMSApp/src/client/app/runs/runs.controller.js
+++ b/TCMSApp/src/client/app/runs/runs.controller.js
@@ -12,21 +12,33 @@
         .module('app.runs')
         .controller('RunsController', RunsController);
 
-    RunsController.$inject = ['$scope', 'logger', 'FakeRunsFactory', 'dataWrapper', 'filterFields'];
+    RunsController.$inject = ['$scope', 'logger', 'FakeRunsFactory', 'dataWrapper',
+        'filterFields', 'RunsApiService', 'moment'];
 
-    function RunsController($scope, logger, fakeRuns, dataWrapper, filterFields) {
+    function RunsController($scope, logger, fakeRuns, dataWrapper, filterFields, RunsApiService, moment) {
 
         var vm = this;
-        vm.runs = dataWrapper.wrapRuns(fakeRuns(100, 10, 3));
-        vm.selectRun = selectRun;
-        vm.selectedRuns = [];
-        vm.selectedRun = (vm.runs.length === 0 ? null : vm.runs[0]);
-        vm.progress = getProgress();
-        vm.runCheckBoxClick = runCheckBoxClick;
-        vm.testClusters = clusterizeTests();
-        vm.filterFields = filterFields.runs.getFields();
+        RunsApiService.query().$promise.then(processData);
 
-        activate();
+        function processData(result) {
+
+            if (result.length === 0) {
+                result = fakeRuns(100, 10, 3);
+                result.forEach(function (data) { RunsApiService.save(data);});
+
+            }
+
+            vm.runs = result;
+            vm.selectRun = selectRun;
+            vm.selectedRuns = [];
+            vm.selectedRun = (vm.runs.length === 0 ? null : vm.runs[0]);
+            vm.progress = getProgress();
+            vm.runCheckBoxClick = runCheckBoxClick;
+            vm.testClusters = clusterizeTests();
+            vm.filterFields = filterFields.runs.getFields();
+
+            activate();
+        }
 
         /**
          * Activates logger notification
@@ -111,5 +123,6 @@
             return clusters;
 
         }
+
     }
 })();

--- a/TCMSApp/src/client/app/runs/runs.html
+++ b/TCMSApp/src/client/app/runs/runs.html
@@ -1,6 +1,6 @@
 <section class="mainbar">
     <div class="matter">
-        <div class="container">
+        <div class="container-fluid">
             <div class="clearfix">
                 <h1>
                     Runs
@@ -66,11 +66,11 @@
                                 <th>
                                     <input type="checkbox" class="runCheckBox" ng-click="vmRuns.runCheckBoxClick($event, $index)">
                                 </th>
-                                <td ng-bind="::runItem.date.toString()"></td>
+                                <td ng-bind="::runItem.dateStart|date : 'shortDate'"></td>
                                 <td ng-bind="::runItem.name"></td>
                                 <td ng-bind="::runItem.build"></td>
                                 <td ng-bind="::runItem.envShort"></td>
-                                <td ng-bind="::runItem.author.toString('short')"></td>
+                                <td>{{::vmRuns.selectedRun.author.firstName}} {{::vmRuns.selectedRun.author.lastName}}</td>
                                 <td>
                                     <span class="label label-{{::runItem.status==='passed'?'success':'danger'}}"
                                           ng-bind="::runItem.status.toUpperCase()"></span>
@@ -85,7 +85,7 @@
                         <div class="panel-heading">
                             &nbsp;
                             <span class="pull-right">
-                                <span ui-sref="runs-execute({run: vmRuns.selectedRun})">
+                                <span ui-sref="runs-execute({id:vmRuns.selectedRun._id, run: vmRuns.selectedRun})">
                                     <span class="glyphicon glyphicon-duplicate"></span>
                                     copy&run &nbsp;
                                 </span>
@@ -107,7 +107,7 @@
                                 </div>
                             </div>
                             <div>
-                                <b>Author: </b>{{::vmRuns.selectedRun.author.toString()}}
+                                <b>Author: </b>{{::vmRuns.selectedRun.author.firstName}} {{::vmRuns.selectedRun.author.lastName}}
                             </div>
                             <b>Environment details:</b>
                             <div>
@@ -120,7 +120,7 @@
                             <thead>
                             <tr>
                                 <th>Name</th>
-                                <th>Status</span></th>
+                                <th>Status</th>
                             </tr>
                             </thead>
                             <tbody ng-repeat="cluster in vmRuns.testClusters">

--- a/TCMSApp/src/client/app/runs/runs.module.js
+++ b/TCMSApp/src/client/app/runs/runs.module.js
@@ -3,7 +3,8 @@
 
     angular.module('app.runs', [
         'app.core',
-        'app.widgets'
+        'app.widgets',
+        'ngResource'
       ]);
 
 })();

--- a/TCMSApp/src/client/app/runs/runs.service.js
+++ b/TCMSApp/src/client/app/runs/runs.service.js
@@ -1,0 +1,16 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('app.runs')
+        .factory('RunsApiService', RunsApiService);
+
+    RunsApiService.$inject = ['$resource', 'apiUrl'];
+
+    function RunsApiService($resource, apiUrl) {
+
+        return $resource(apiUrl.host + apiUrl.runs + '/:id', {id: '@id'});
+
+    }
+
+})();

--- a/TCMSApp/src/client/index.html
+++ b/TCMSApp/src/client/index.html
@@ -15,8 +15,8 @@
     <!-- build:css styles/lib.css -->
     <link rel="stylesheet" href="/bower_components/font-awesome/css/font-awesome.min.css" />
     <!-- bower:css -->
-    <link rel='stylesheet' href='/bower_components/angular-toastr/dist/angular-toastr.css' />
-    <link rel='stylesheet' href='/bower_components/bootstrap-css-only/css/bootstrap.css' />
+    <link rel="stylesheet" href="/bower_components/angular-toastr/dist/angular-toastr.css" />
+    <link rel="stylesheet" href="/bower_components/bootstrap-css-only/css/bootstrap.css" />
     <!-- endbower -->
     <!-- endbuild -->
 
@@ -128,6 +128,7 @@
     <script src="/src/client/app/runs/runs-exec/runs-execute.controller.js"></script>
     <script src="/src/client/app/runs/runs.controller.js"></script>
     <script src="/src/client/app/runs/runs.route.js"></script>
+    <script src="/src/client/app/runs/runs.service.js"></script>
     <script src="/src/client/app/tests/tests-create.controller.js"></script>
     <script src="/src/client/app/tests/tests-list.controller.js"></script>
     <script src="/src/client/app/tests/tests.route.js"></script>

--- a/TCMSApp/src/client/styles/styles.less
+++ b/TCMSApp/src/client/styles/styles.less
@@ -332,6 +332,11 @@ a.fa:hover {
 .tabsNotSelected{
     background-color: @color_white;
 }
+.tableInput{
+    background-color: transparent;
+    border: none;
+}
+
 
 //---------landing styles---------//
 
@@ -402,3 +407,4 @@ iframe {
 }
 
 //---------end landing styles---------//
+

--- a/TCMSApp/src/server/model/mschemas/run.js
+++ b/TCMSApp/src/server/model/mschemas/run.js
@@ -19,7 +19,7 @@ var runSchema = new Schema({
         },
         previousRunId: mongoose.Schema.Types.ObjectId,
         dateStart: {type: Date, required: true},
-        dateEnd: {type: Date, required: true},
+        dateEnd: {type: Date},
         build: Number,
         envShort: String,
         envFull: {},
@@ -35,33 +35,24 @@ var runSchema = new Schema({
         },
         //the
         tests: [{
-            testName: {type: String, required: true},
-            testDescription: {type: String, required: true},
+            name: {type: String, required: true},
+            testDescription: {type: String},
             automated: Boolean,
-            preConditions: {type: String, required: true},
+            preConditions: {type: String},
+            suite: String,
             steps: [{
-                stepNumber: Number,
-                stepDescription: {type: String, required: true},
-                expectedResult: {type: String, required: true},
+                number: Number,
+                action: {type: String, required: true},
+                expected: {type: String, required: true},
 
                 status: {
                     type: String,
-                    validate: {
-                        validator: function (v) {
-                            return /passed, blocked, failed/.test(v);
-                        },
-                        message: '{VALUE} is not valid status!'
-                    }
+                    enum:['passed','blocked', 'failed']
                 }
             }],
             status: {
                 type: String,
-                validate: {
-                    validator: function (v) {
-                        return /passed|executing|failed/.test(v);
-                    },
-                    message: '{VALUE} is not valid status!'
-                }
+                enum:['passed','blocked', 'failed']
             }
         }]
     });


### PR DESCRIPTION
Check out
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23issuecomment-173275198%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23issuecomment-173306944%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23issuecomment-173333406%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23discussion_r50428297%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23discussion_r50428345%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23discussion_r50429338%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23discussion_r50429556%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/commit/d34d108ef666000c5ea2da1483ce9eeaa12de055%23commitcomment-15591638%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23discussion_r50543034%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23issuecomment-173275198%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6047.33%25%60%5Cn%3E%20Merging%20%2A%2A%23149%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20decrease%20coverage%20by%20%2A%2A-0.40%25%2A%2A%20as%20of%20%5B%6099dd363%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23149%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2065%20%20%20%20%20%2066%20%20%20%20%20%2B1%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%201060%20%20%20%201090%20%20%20%20%2B30%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hit%20%20%20%20%20%20%20%20%20%20%20%20506%20%20%20%20%20516%20%20%20%20%2B10%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn-%20Missed%20%20%20%20%20%20%20%20%20554%20%20%20%20%20574%20%20%20%20%2B20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%6099dd363%60%5D%5B3%5D%5Cn%5Cn%5Cn-----%5Cn%23%23%23%20%5BUncovered%20Suggestions%5D%5B2%5D%5Cn%5Cn1.%20%60%2B1.47%25%60%20via%20%5B...ake-tests.factory.js%23115...130%5D%28https%3A//codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/blocks/fakers/fake-tests.factory.js%3Fref%3D99dd3633c49d752cdc666ee0205371c67cea30e6%23115%29%20%5Cn1.%20%60%2B1.47%25%60%20via%20%5B...create.controller.js%2370...85%5D%28https%3A//codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/tests/tests-create.controller.js%3Fref%3D99dd3633c49d752cdc666ee0205371c67cea30e6%2370%29%20%5Cn1.%20%60%2B1.20%25%60%20via%20%5B...create.controller.js%2311...23%5D%28https%3A//codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/tests/tests-create.controller.js%3Fref%3D99dd3633c49d752cdc666ee0205371c67cea30e6%2311%29%20%5Cn1.%20%2A%5BSee%207%20more...%5D%5B2%5D%2A%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012%3Fref%3D99dd3633c49d752cdc666ee0205371c67cea30e6%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012/features/suggestions%3Fref%3D99dd3633c49d752cdc666ee0205371c67cea30e6%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012/commit/99dd3633c49d752cdc666ee0205371c67cea30e6%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012/compare/d3d85a47744c90b527021d44f0d41d8a44844e6b...99dd3633c49d752cdc666ee0205371c67cea30e6%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-01-20T17%3A04%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22you%27ve%20pushed%20your%20branch%20without%20ngResource%20in%20package.json%22%2C%20%22created_at%22%3A%20%222016-01-20T18%3A03%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22Have%20you%20already%20added%20the%20ngResource%20to%20master%20branch%3F%22%2C%20%22created_at%22%3A%20%222016-01-20T19%3A29%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16047980%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OlehKSS%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20d34d108ef666000c5ea2da1483ce9eeaa12de055%20TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23discussion_r50428297%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22it%20is%20%60activate%60%20logic%22%2C%20%22created_at%22%3A%20%222016-01-21T16%3A54%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js%3AL5-44%22%7D%2C%20%22Pull%20d34d108ef666000c5ea2da1483ce9eeaa12de055%20TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23discussion_r50429338%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22add%20constant%20or%20comment%20that%20this%20is%20managing%20of%20enter%20click%22%2C%20%22created_at%22%3A%20%222016-01-21T17%3A00%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js%3AL5-44%22%7D%2C%20%22Pull%20d34d108ef666000c5ea2da1483ce9eeaa12de055%20TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23discussion_r50428345%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22we%20can%20do%20it%20not%20in%20callback%22%2C%20%22created_at%22%3A%20%222016-01-21T16%3A54%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js%3AL5-44%22%7D%2C%20%22Pull%20d34d108ef666000c5ea2da1483ce9eeaa12de055%20TCMSApp/src/client/app/runs/runs-exec/runs-exec.route.js%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/149%23discussion_r50429556%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22please%20explain%20what%20is%20it%22%2C%20%22created_at%22%3A%20%222016-01-21T17%3A02%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22squash%20-%20%7Bbool%7Cstring%3D%7D%3A%20squash%20configures%20how%20a%20default%20parameter%20value%20is%20represented%20in%20the%20URL%20when%20the%20current%20parameter%20value%20is%20the%20same%20as%20the%20default%20value.%20If%20squash%20is%20not%20set%2C%20it%20uses%20the%20configured%20default%20squash%20policy.%20%28See%20defaultSquashPolicy%28%29%29%5Cr%5Cn%5Cr%5CnThere%20are%20three%20squash%20settings%3A%5Cr%5Cn%5Cr%5Cnfalse%3A%20The%20parameter%27s%20default%20value%20is%20not%20squashed.%20It%20is%20encoded%20and%20included%20in%20the%20URL%5Cr%5Cntrue%3A%20The%20parameter%27s%20default%20value%20is%20omitted%20from%20the%20URL.%20If%20the%20parameter%20is%20preceeded%20and%20followed%20by%20slashes%20in%20the%20state%27s%20url%20declaration%2C%20then%20one%20of%20those%20slashes%20are%20omitted.%20This%20can%20allow%20for%20cleaner%20looking%20URLs.%5Cr%5Cn%5C%22%3Carbitrary%20string%3E%5C%22%3A%20The%20parameter%27s%20default%20value%20is%20replaced%20with%20an%20arbitrary%20placeholder%20of%20your%20choice.%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A39%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16047980%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OlehKSS%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/runs/runs-exec/runs-exec.route.js%3AL16-30%22%7D%2C%20%22Commit%20d34d108ef666000c5ea2da1483ce9eeaa12de055%20TCMSApp/src/client/app/runs/runs.html%2013%2069%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/commit/d34d108ef666000c5ea2da1483ce9eeaa12de055%23commitcomment-15591638%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22we%20can%20use%20just%20angular%20date%20filter%21%22%2C%20%22created_at%22%3A%20%222016-01-21T17%3A08%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/runs/runs.html%3AL69%20%28d34d108%29%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/149#issuecomment-173275198'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `47.33%`
> Merging **#149** into **master** will decrease coverage by **-0.40%** as of [`99dd363`][3]
```diff
@@            master    #149   diff @@
======================================
Files           65      66     +1
Stmts         1060    1090    +30
Branches         0       0
Methods          0       0
======================================
+ Hit            506     516    +10
Partial          0       0
- Missed         554     574    +20
```
> Review entire [Coverage Diff][4] as of [`99dd363`][3]
-----
### [Uncovered Suggestions][2]
1. `+1.47%` via [...ake-tests.factory.js#115...130](https://codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/blocks/fakers/fake-tests.factory.js?ref=99dd3633c49d752cdc666ee0205371c67cea30e6#115)
1. `+1.47%` via [...create.controller.js#70...85](https://codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/tests/tests-create.controller.js?ref=99dd3633c49d752cdc666ee0205371c67cea30e6#70)
1. `+1.20%` via [...create.controller.js#11...23](https://codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/tests/tests-create.controller.js?ref=99dd3633c49d752cdc666ee0205371c67cea30e6#11)
1. *[See 7 more...][2]*
[1]: https://codecov.io/github/ITsvetkoFF/Kv-012?ref=99dd3633c49d752cdc666ee0205371c67cea30e6
[2]: https://codecov.io/github/ITsvetkoFF/Kv-012/features/suggestions?ref=99dd3633c49d752cdc666ee0205371c67cea30e6
[3]: https://codecov.io/github/ITsvetkoFF/Kv-012/commit/99dd3633c49d752cdc666ee0205371c67cea30e6
[4]: https://codecov.io/github/ITsvetkoFF/Kv-012/compare/d3d85a47744c90b527021d44f0d41d8a44844e6b...99dd3633c49d752cdc666ee0205371c67cea30e6
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> you've pushed your branch without ngResource in package.json
- <a href='https://github.com/OlehKSS'><img border=0 src='https://avatars.githubusercontent.com/u/16047980?v=3' height=16 width=16'></a> Have you already added the ngResource to master branch?
- [ ] <a href='#crh-comment-Pull d34d108ef666000c5ea2da1483ce9eeaa12de055 TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/149#discussion_r50428297'>File: TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js:L5-44</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> it is `activate` logic
- [ ] <a href='#crh-comment-Pull d34d108ef666000c5ea2da1483ce9eeaa12de055 TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js 26'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/149#discussion_r50428345'>File: TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js:L5-44</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> we can do it not in callback
- [ ] <a href='#crh-comment-Pull d34d108ef666000c5ea2da1483ce9eeaa12de055 TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/149#discussion_r50429338'>File: TCMSApp/src/client/app/runs/runs-exec/runs-edit.controller.js:L5-44</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> add constant or comment that this is managing of enter click
- [ ] <a href='#crh-comment-Pull d34d108ef666000c5ea2da1483ce9eeaa12de055 TCMSApp/src/client/app/runs/runs-exec/runs-exec.route.js 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/149#discussion_r50429556'>File: TCMSApp/src/client/app/runs/runs-exec/runs-exec.route.js:L16-30</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> please explain what is it
- <a href='https://github.com/OlehKSS'><img border=0 src='https://avatars.githubusercontent.com/u/16047980?v=3' height=16 width=16'></a> squash - {bool|string=}: squash configures how a default parameter value is represented in the URL when the current parameter value is the same as the default value. If squash is not set, it uses the configured default squash policy. (See defaultSquashPolicy())
There are three squash settings:
false: The parameter's default value is not squashed. It is encoded and included in the URL
true: The parameter's default value is omitted from the URL. If the parameter is preceeded and followed by slashes in the state's url declaration, then one of those slashes are omitted. This can allow for cleaner looking URLs.
"<arbitrary string>": The parameter's default value is replaced with an arbitrary placeholder of your choice.
- [ ] <a href='#crh-comment-Commit d34d108ef666000c5ea2da1483ce9eeaa12de055 TCMSApp/src/client/app/runs/runs.html 13 69'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/commit/d34d108ef666000c5ea2da1483ce9eeaa12de055#commitcomment-15591638'>File: TCMSApp/src/client/app/runs/runs.html:L69 (d34d108)</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> we can use just angular date filter!


<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/149?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/149?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-012/pull/149'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>