### PR TITLE
Implement validation.

### DIFF
--- a/TCMSApp/src/client/app/defects/add-defect.controller.js
+++ b/TCMSApp/src/client/app/defects/add-defect.controller.js
@@ -53,17 +53,10 @@
 
                             vmDefectModal.cancel = function () {
                                 allowStateChange = true;
-
                                 $uibModalInstance.dismiss('cancel');
                                 $state.go($stateParams.previousState);
                             };
 
-                            /*function getNewDefect() {
-                             return dataservice.getNewDefect().then(function (data) {
-                             //var debug = data.getById("whoFind");
-                             return data;
-                             });
-                             }*/
                             vmDefectModal.post = function () {
                                 allowStateChange = true;
 
@@ -86,11 +79,10 @@
                                     $uibModalInstance.close();
                                     $state.go($stateParams.
                                         previousState, $stateParams, {
-                                        reload: true, inherit: false,
-                                        notify: true
+                                        reload: true, inherit: false, notify: true
                                     });
                                 }, function error(message) {
-                                    vmDefectModal.error = 'Error: ' + message.status + ' ' + message.statusText + '.';
+                                    vmDefectModal.error = 'Error: ' + message.data.errmsg;
                                 });
 
                             };

--- a/TCMSApp/src/client/app/defects/add-defect.controller.js
+++ b/TCMSApp/src/client/app/defects/add-defect.controller.js
@@ -81,12 +81,18 @@
                                 };
 
                                 var defectsInfo = $resource(apiUrl.defects, {}, {});
+                                var result = defectsInfo.save(sample).$promise.then(function success() {
+                                    vmDefectModal.error = 'Success.';
+                                    $uibModalInstance.close();
+                                    $state.go($stateParams.
+                                        previousState, $stateParams, {
+                                        reload: true, inherit: false,
+                                        notify: true
+                                    });
+                                }, function error(message) {
+                                    vmDefectModal.error = 'Error: ' + message.status + ' ' + message.statusText + '.';
+                                });
 
-                                defectsInfo.save(sample);
-                                // updateDefects();
-                                $uibModalInstance.close();
-                                $state.go($stateParams.previousState, $stateParams, {reload: true, inherit: false,
-                                    notify: true});
                             };
 
                             // prevent state changing without interraction with modal controlls
@@ -96,6 +102,19 @@
                                     event.preventDefault();
                                 }
                             });
+
+                            vmDefectModal.noActivePostDefect = function () {
+                                if (vmDefectModal.description !== undefined &&
+                                    vmDefectModal.bugName !== undefined &&
+                                    vmDefectModal.description.length !== 0 &&
+                                    vmDefectModal.bugName.length !== 0) {
+                                    return true;
+                                }
+                                else {
+
+                                    return false;
+                                }
+                            };
                         },
                         controllerAs: 'vmDefectModal',
                         backdrop: 'static'

--- a/TCMSApp/src/client/app/defects/add-defect.template.html
+++ b/TCMSApp/src/client/app/defects/add-defect.template.html
@@ -42,10 +42,15 @@
             <label for="testCase">Steps To Reproduce:</label>
         <textarea class="form-control" id="testCase" rows="2" ng-model="vmDefectModal.stepsToReproduce"></textarea>
             </div>
+            <div class="errorMessage">
+                * - required fields<br>
+                {{vmDefectModal.error}}
+            </div>
             </div>
             <div class="modal-footer">
             <button type="button" class="btn btn-default" ng-click="vmDefectModal.cancel()">Cancel</button>
-            <button type="button" class="btn btn-primary" ng-click="vmDefectModal.post()">Post</button>
+                <button ng-disabled="!vmDefectModal.noActivePostDefect()" type="button" class="btn btn-primary"
+                        ng-click="vmDefectModal.post()">Post</button>
             </div>
     </script>
 </div>

--- a/TCMSApp/src/client/app/defects/add-defect.template.html
+++ b/TCMSApp/src/client/app/defects/add-defect.template.html
@@ -7,7 +7,7 @@
         <div class="modal-body">
             <div class="row">
             <div class="form-group col-md-9">
-            <label for="errorname">Name of the defect:</label>
+            <label for="errorname">Name of the defect*:</label>
         <input type="text" class="form-control" id="errorname" ng-model="vmDefectModal.bugName">
             </div>
             <div class="form-group col-md-3">
@@ -31,7 +31,7 @@
             </div>
             </div>
             <div class="form-group">
-            <label for="description">Description:</label>
+            <label for="description">Description*:</label>
         <textarea class="form-control" id="description" rows="3" ng-model="vmDefectModal.description"></textarea>
 
             </div>


### PR DESCRIPTION
Button POST is no active while description and bugs name are empty
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/177%23issuecomment-174556502%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/177%23issuecomment-174950263%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/177%23issuecomment-174556502%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6042.24%25%60%5Cn%3E%20Merging%20%2A%2A%23177%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20decrease%20coverage%20by%20%2A%2A-4.48%25%2A%2A%20as%20of%20%5B%60708504a%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23177%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2065%20%20%20%20%20%2070%20%20%20%20%20%2B5%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%201085%20%20%20%201205%20%20%20%2B120%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hit%20%20%20%20%20%20%20%20%20%20%20%20507%20%20%20%20%20509%20%20%20%20%20%2B2%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn-%20Missed%20%20%20%20%20%20%20%20%20578%20%20%20%20%20696%20%20%20%2B118%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%60708504a%60%5D%5B3%5D%5Cn%5Cn%5Cn-----%5Cn%23%23%23%20%5BUncovered%20Suggestions%5D%5B2%5D%5Cn%5Cn1.%20%60%2B1.41%25%60%20via%20%5B...ake-tests.factory.js%23115...131%5D%28https%3A//codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/blocks/fakers/fake-tests.factory.js%3Fref%3D708504ac9ae2539b719aeba0b866b2d29470a343%23115%29%20%5Cn1.%20%60%2B1.32%25%60%20via%20%5B...create.controller.js%2370...85%5D%28https%3A//codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/tests/tests-create.controller.js%3Fref%3D708504ac9ae2539b719aeba0b866b2d29470a343%2370%29%20%5Cn1.%20%60%2B1.24%25%60%20via%20%5B...defect.controller.js%2338...52%5D%28https%3A//codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/defects/add-defect.controller.js%3Fref%3D708504ac9ae2539b719aeba0b866b2d29470a343%2338%29%20%5Cn1.%20%2A%5BSee%207%20more...%5D%5B2%5D%2A%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012%3Fref%3D708504ac9ae2539b719aeba0b866b2d29470a343%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012/features/suggestions%3Fref%3D708504ac9ae2539b719aeba0b866b2d29470a343%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012/commit/708504ac9ae2539b719aeba0b866b2d29470a343%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012/compare/98d1500b5a63bfdc0b61012cd921f9419b845f20...708504ac9ae2539b719aeba0b866b2d29470a343%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-01-25T16%3A07%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%223%20notes.%5Cr%5Cn%5Cr%5Cn1.%20we%20can%20not%20show%20user%20the%20line%20%60Error%3A%20400%20Bad%20Request.%60%20We%20need%20to%20show%20something%20meaningful.%20We%20need%20to%20change%20backend%20validation%20message%20in%20case%20of%20entering%20the%20same%20name%20again%20%28current%20is%20%5Cr%5Cn%60%60%60js%5Cr%5Cn%5C%22E11000%20duplicate%20key%20error%20index%3A%20TCMSdb.defects.%24name_1%20dup%20key%3A%20%7B%20%3A%20%5C%22dfdz%5C%22%20%7D%5C%22%5C%22E11000%20duplicate%20key%20error%20index%3A%20TCMSdb.defects.%24name_1%20dup%20key%3A%20%7B%20%3A%20%5C%22dfdz%5C%22%20%7D%5C%22%5Cr%5Cn%60%60%60%5Cr%5Cn%29%20and%20display%20it.%5Cr%5Cn%5Cr%5Cn2.%20we%20need%20to%20add%20%60%2A%60%20near%20the%20required%20fields%20labels%5Cr%5Cn%5Cr%5Cn3.%20there%20is%20a%20way%20to%20close%20the%20modal%20so%20that%20the%20route%20won%27t%20be%20changed%21%20%22%2C%20%22created_at%22%3A%20%222016-01-26T10%3A38%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/177#issuecomment-174556502'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `42.24%`
> Merging **#177** into **master** will decrease coverage by **-4.48%** as of [`708504a`][3]
```diff
@@            master    #177   diff @@
======================================
Files           65      70     +5
Stmts         1085    1205   +120
Branches         0       0
Methods          0       0
======================================
+ Hit            507     509     +2
Partial          0       0
- Missed         578     696   +118
```
> Review entire [Coverage Diff][4] as of [`708504a`][3]
-----
### [Uncovered Suggestions][2]
1. `+1.41%` via [...ake-tests.factory.js#115...131](https://codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/blocks/fakers/fake-tests.factory.js?ref=708504ac9ae2539b719aeba0b866b2d29470a343#115)
1. `+1.32%` via [...create.controller.js#70...85](https://codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/tests/tests-create.controller.js?ref=708504ac9ae2539b719aeba0b866b2d29470a343#70)
1. `+1.24%` via [...defect.controller.js#38...52](https://codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/defects/add-defect.controller.js?ref=708504ac9ae2539b719aeba0b866b2d29470a343#38)
1. *[See 7 more...][2]*
[1]: https://codecov.io/github/ITsvetkoFF/Kv-012?ref=708504ac9ae2539b719aeba0b866b2d29470a343
[2]: https://codecov.io/github/ITsvetkoFF/Kv-012/features/suggestions?ref=708504ac9ae2539b719aeba0b866b2d29470a343
[3]: https://codecov.io/github/ITsvetkoFF/Kv-012/commit/708504ac9ae2539b719aeba0b866b2d29470a343
[4]: https://codecov.io/github/ITsvetkoFF/Kv-012/compare/98d1500b5a63bfdc0b61012cd921f9419b845f20...708504ac9ae2539b719aeba0b866b2d29470a343
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> 3 notes.
1. we can not show user the line `Error: 400 Bad Request.` We need to show something meaningful. We need to change backend validation message in case of entering the same name again (current is
```js
"E11000 duplicate key error index: TCMSdb.defects.$name_1 dup key: { : "dfdz" }""E11000 duplicate key error index: TCMSdb.defects.$name_1 dup key: { : "dfdz" }"
```
) and display it.
2. we need to add `*` near the required fields labels
3. there is a way to close the modal so that the route won't be changed!


<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/177?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/177?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-012/pull/177'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>