### PR TITLE
Added validation errors to user

### DIFF
--- a/TCMSApp/package.json
+++ b/TCMSApp/package.json
@@ -20,6 +20,7 @@
     "jsdoc": "^3.4.0",
     "mongodb": "^2.1.4",
     "mongoose": "^4.3.1",
+    "mongoose-unique-validator":"^0.6.2",
     "morgan": "^1.1.1",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",

--- a/TCMSApp/src/client/app/defects/add-defect.controller.js
+++ b/TCMSApp/src/client/app/defects/add-defect.controller.js
@@ -13,10 +13,10 @@
         .controller('AddDefectController', AddDefectController);
 
     AddDefectController.$inject = ['$uibModal', '$state', '$scope', '$stateParams', '$rootScope', 'logger',
-        '$resource', 'apiUrl', 'moment'];
+        '$resource', 'apiUrl', 'moment', 'user'];
 
     function AddDefectController($uibModal, $state, $scope, $stateParams, $rootScope, logger, $resource, apiUrl,
-    moment) {
+    moment, user) {
 
         var vm = this;
         vm.open = openAddDefectModal;
@@ -34,11 +34,11 @@
                 $uibModal.open({
                         templateUrl: 'addDefectModalTemplate.html',
                         controller: function ($uibModalInstance, $state, $scope, $rootScope, logger, $resource,
-                        moment) {
+                        moment, user) {
                             var vmDefectModal = this;
                             var allowStateChange = false;
                             vmDefectModal.bugName = '';
-                            vmDefectModal.whoFind = '';
+                            vmDefectModal.reporter = user.firstName + ' ' + user.lastName;
                             vmDefectModal.assignedTo = '';
                             vmDefectModal.priority = 'Critical';
                             vmDefectModal.dateOfDefectCreation = moment();
@@ -60,11 +60,9 @@
                             vmDefectModal.post = function () {
                                 allowStateChange = true;
 
-                                //var infoPromise = getNewDefect();
                                 var sample = {
                                     name: vmDefectModal.bugName,
-                                    whoFind: vmDefectModal.whoFind,
-                                    assignedTo: vmDefectModal.assignedTo,
+                                    reporter: user.id,
                                     dateOfDefectCreation: vmDefectModal.dateOfDefectCreation,
                                     priority: vmDefectModal.priority,
                                     chooseFile: vmDefectModal.chooseFile,
@@ -82,7 +80,9 @@
                                         reload: true, inherit: false, notify: true
                                     });
                                 }, function error(message) {
-                                    vmDefectModal.error = 'Error: ' + message.data.errmsg;
+                                    //vmDefectModal.error = 'Error: ' + message.data.errmsg;
+                                    vmDefectModal.error = message.data.errors.name.message;
+
                                 });
 
                             };
@@ -109,7 +109,8 @@
                             };
                         },
                         controllerAs: 'vmDefectModal',
-                        backdrop: 'static'
+                        backdrop: 'static',
+                        keyboard :false
                     });
             }
         }

--- a/TCMSApp/src/client/app/defects/add-defect.controller.spec.js
+++ b/TCMSApp/src/client/app/defects/add-defect.controller.spec.js
@@ -1,0 +1,54 @@
+/* jshint -W117, -W030 */
+describe('Tests Add-Defects Open Model', function() {
+    var controller, controllerModal, scope, state;
+    var Trello = {
+        authorized: function() {
+            return true;
+        },
+        authorize: function() {},
+        get: function() {}
+    };
+    beforeEach(module('app.core'));
+    beforeEach(function() {
+        module(function($provide) {
+            $provide.constant('Trello', Trello);
+        });
+    });
+    beforeEach(function () {
+        bard.appModule('app.defects');
+        bard.inject('$controller', '$rootScope', '$httpBackend', '$state', 'apiUrl', 'user', '$uibModal');
+    });
+
+    beforeEach(function () {
+        scope = $rootScope.$new();
+        state = {};
+        state.$current = {};
+        state.$current.name = 'defects';
+        state.previousState = 'defects';
+        state.run = 'true';
+        controller = $controller('AddDefectController', {$scope: scope, $state: state, $stateParams:state});
+        var httpBackend = $httpBackend;
+        httpBackend.when('GET', apiUrl.user).respond(
+            [
+                {
+                    '_id':'56b323080d43df5011807f2a',
+                    'lastName':'Mart',
+                    'firstName':'Alex',
+                    'email':'tester1@soft.com',
+                    'password':'$2a$10$X1mcILfK.HfqBk3oUsszOeAi2RitZcaVCd4Awl4pmsuBL2vCf0Bti',
+                    '__v':0,
+                    'projects':[]}
+            ]
+        );
+        httpBackend.flush();
+        $rootScope.$digest();
+    });
+
+    bard.verifyNoOutstandingHttpRequests();
+
+    describe('Add-Defects Controller', function () {
+        it('should be created successfully', function () {
+            expect(controller).to.be.defined;
+        });
+    });
+});

--- a/TCMSApp/src/client/app/defects/add-defect.template.html
+++ b/TCMSApp/src/client/app/defects/add-defect.template.html
@@ -1,56 +1,63 @@
 <div>
     <script type="text/ng-template" id="addDefectModalTemplate.html">
         <div class="modal-header">
-            <button type="button" class="close" ng-click="vmDefectModal.cancel()"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title">Add defect</h4>
+            <button type="button" class="close" ng-click="vmDefectModal.cancel()"><span
+                aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title">Add defect</h4>
         </div>
         <div class="modal-body">
             <div class="row">
-            <div class="form-group col-md-9">
-            <label for="errorname">Name of the defect*:</label>
-        <input type="text" class="form-control" id="errorname" ng-model="vmDefectModal.bugName">
-            </div>
-            <div class="form-group col-md-3">
-            <label>Priority:</label>
-        <select class="form-control" ng-model="vmDefectModal.priority">
-            <option>Critical</option>
-            <option>High</option>
-            <option>Normal</option>
-            <option>Low</option>
-            </select>
-            </div>
+                <div class="form-group col-md-9">
+                    <label for="errorname">Name of the defect*:</label>
+                    <input type="text" class="form-control" id="errorname" ng-model="vmDefectModal.bugName">
+                </div>
+                <div class="form-group col-md-3">
+                    <label>Priority:</label>
+                    <select class="form-control" ng-model="vmDefectModal.priority">
+                        <option>Critical</option>
+                        <option>High</option>
+                        <option>Normal</option>
+                        <option>Low</option>
+                    </select>
+                </div>
             </div>
             <div class="row">
-            <div class="form-group col-md-6">
-            <label for="whoFind">Who Found:</label>
-        <input type="text" class="form-control" id="whoFind" ng-model="vmDefectModal.whoFind">
-            </div>
-            <div class="form-group col-md-6">
-            <label for="assignedTo">Assigned to:</label>
-        <input type="text" class="form-control" id="assignedTo" ng-model="vmDefectModal.assignedTo">
-            </div>
+                <div class="form-group col-md-6">
+                    <label for="Reporter">Reporter:</label>
+                    <input type="text" class="form-control" id="Reporter" ng-model="vmDefectModal.reporter"
+                           disabled>
+                </div>
+                <div class="form-group col-md-6">
+                    <label for="assignedTo">Assigned to:</label>
+                    <input type="text" class="form-control" id="assignedTo" ng-model="vmDefectModal.assignedTo">
+                </div>
             </div>
             <div class="form-group">
-            <label for="description">Description*:</label>
-        <textarea class="form-control" id="description" rows="3" ng-model="vmDefectModal.description"></textarea>
+                <label for="description">Description*:</label>
+                <textarea class="form-control" id="description" rows="3"
+                          ng-model="vmDefectModal.description"></textarea>
 
             </div>
             <div class="form-group" enctype="multipart/form-data" method="post">
-            <input type="file" value="Attach file" id="choose-file" ng-model="vmDefectModal.chooseFile">
+                <input type="file" value="Attach file" id="choose-file" ng-model="vmDefectModal.chooseFile">
             </div>
             <div class="form-group">
-            <label for="testCase">Steps To Reproduce:</label>
-        <textarea class="form-control" id="testCase" rows="2" ng-model="vmDefectModal.stepsToReproduce"></textarea>
+                <label for="testCase">Steps To Reproduce:</label>
+                <textarea class="form-control" id="testCase" rows="2"
+                          ng-model="vmDefectModal.stepsToReproduce"></textarea>
             </div>
             <div class="errorMessage">
                 * - required fields<br>
-                {{vmDefectModal.error}}
+                <span class="errorMessageSpan">
+                    {{vmDefectModal.error}}
+                </span>
             </div>
-            </div>
-            <div class="modal-footer">
+        </div>
+        <div class="modal-footer">
             <button type="button" class="btn btn-default" ng-click="vmDefectModal.cancel()">Cancel</button>
-                <button ng-disabled="!vmDefectModal.noActivePostDefect()" type="button" class="btn btn-primary"
-                        ng-click="vmDefectModal.post()">Post</button>
-            </div>
+            <button ng-disabled="!vmDefectModal.noActivePostDefect()" type="button" class="btn btn-primary"
+                    ng-click="vmDefectModal.post()">Post
+            </button>
+        </div>
     </script>
 </div>

--- a/TCMSApp/src/client/app/defects/defects.controller.js
+++ b/TCMSApp/src/client/app/defects/defects.controller.js
@@ -9,7 +9,7 @@
     /* @ngInject */
     function DefectsController(logger, $uibModal, getDefects, $state, $resource, apiUrl, filterFields) {
         var vm = this;
-        var defectsInfo = $resource(apiUrl.defects, {}, {});
+        var defectsInfo = $resource(apiUrl.defects + '/?populate=reporter', {}, {});
         vm.arrayDefects = [];
         vm.statusMessage = 'Loading defects...';
         vm.countOfDefects = -1;

--- a/TCMSApp/src/client/app/defects/defects.controller.spec.js
+++ b/TCMSApp/src/client/app/defects/defects.controller.spec.js
@@ -1,4 +1,115 @@
 /* jshint -W117, -W030 */
-describe('DefectsController', function() {
+describe('Tests Defects', function() {
+    var controller;
+    beforeEach(function () {
+            bard.appModule('app.defects');
+            bard.inject('$controller', '$rootScope', '$httpBackend', '$state', 'apiUrl');
+        });
 
+    beforeEach(function () {
+            var scope = $rootScope.$new();
+            var state = {};
+            state.$current = {};
+            state.$current.name = 'defects';
+            controller = $controller('DefectsController', {$scope: scope, $state: state});
+            var httpBackend = $httpBackend;
+            httpBackend.when('GET', apiUrl.defects + '/?populate=reporter').respond(
+                [
+                    {
+                        '_id':'56b0827025c2c3cc1146fc05',
+                        'name':'ErrorName14587',
+                        'reporter':'56b2056154fafdfc1586096a',
+                        'dateOfDefectCreation':'2016-02-02T10:17:34.410Z',
+                        'priority':'Normal',
+                        'description':'rfrfrfnhvnslhrrhzhvsc\nhvwhnghnecw45645cshgkvmm',
+                        'stepsToReproduce':['gfhdjhnbjnjnyvnynhnjnkynk'],
+                        '__v':0
+                    },
+                    {
+                        '_id':'56b31a6748586dc017406713',
+                        'name':'ErrorРусскийъыУкраїнська',
+                        'reporter':'56b319d848586dc017406712',
+                        'dateOfDefectCreation':'2016-02-04T09:29:14.516Z',
+                        'priority':'Low',
+                        'description':'DEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionD' +
+                        'EscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscr' +
+                        'iptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscripti' +
+                        'onDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDE' +
+                        'scriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscri' +
+                        'ptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscriptionDEscription',
+                        'stepsToReproduce':['STEPtoReproduce 14578STEPtoReproduce 14578STEPtoReproduce 14578STEPtoRep' +
+                        'roduce 14578STEPtoReproduce 14578STEPtoReproduce 14578STEPtoReproduce 14578STEPtoReproduce 1' +
+                        '4578STEPtoReproduce 14578STEPtoReproduce 14578STEPtoReproduce 14578STEPtoReproduce 14578STEP' +
+                        'toReproduce 14578STEPtoReproduce 14578STEPtoReproduce 14578STEPtoReproduce 14578STEPtoReprod' +
+                        'uce 14578STEPtoReproduce 1457847rvbjehvmejl'],
+                        '__v':0
+                    },
+                    {
+                        '_id':'56b31ef548586dc017406715',
+                        'name':'ErrorNamefrfrcrfgagf',
+                        'reporter':'56b319d848586dc017406712',
+                        'dateOfDefectCreation':'2016-02-04T09:50:13.815Z',
+                        'priority':'Critical',
+                        'description':'Description14122444dghv4c2',
+                        'stepsToReproduce':['cfhvdnhybnvnStepToReproduie'],
+                        '__v':0
+                    }
+                ]
+            );
+            httpBackend.flush();
+            $rootScope.$apply();
+        });
+
+    bard.verifyNoOutstandingHttpRequests();
+
+    describe('Defects Controller', function () {
+        it('should be created successfully', function () {
+            expect(controller).to.be.defined;
+        });
+    });
+
+    beforeEach(function() {
+        controller.setCurrentDefect(controller.arrayDefects[2]);
+    });
+    describe('Current Defect', function () {
+        it('should be right current defect', function () {
+            expect(controller.currentDefect.name).to.equal('ErrorNamefrfrcrfgagf');
+            expect(controller.currentDefect.reporter).to.equal('56b319d848586dc017406712');
+            expect(controller.currentDefect.description).to.equal('Description14122444dghv4c2');
+        });
+    });
+});
+
+describe('Tests Defects Empty Database', function() {
+    var controller;
+    beforeEach(function () {
+        bard.appModule('app.defects');
+        bard.inject('$controller', '$rootScope', '$httpBackend', '$state', 'apiUrl');
+    });
+
+    beforeEach(function () {
+        var scope = $rootScope.$new();
+        var state = {};
+        state.$current = {};
+        state.$current.name = 'defects';
+        controller = $controller('DefectsController', {$scope: scope, $state: state});
+        var httpBackend = $httpBackend;
+        httpBackend.when('GET', apiUrl.defects + '/?populate=reporter').respond([]);
+        httpBackend.flush();
+        $rootScope.$apply();
+    });
+
+    bard.verifyNoOutstandingHttpRequests();
+
+    describe('Defects Controller', function () {
+        it('should be created successfully', function () {
+            expect(controller).to.be.defined;
+        });
+    });
+
+    describe('No defects', function () {
+        it('should be no defects', function () {
+            expect(controller.statusMessage).to.equal('There are no defects');
+        });
+    });
 });

--- a/TCMSApp/src/client/app/defects/defects.html
+++ b/TCMSApp/src/client/app/defects/defects.html
@@ -92,8 +92,8 @@
                                 <b>Name:</b>
                                 {{vmDefects.currentDefect.name}}
                                 <br>
-                                <b>Found:</b>
-                                {{vmDefects.currentDefect.whoFind}}
+                                <b>Reporter:</b>
+                                {{vmDefects.currentDefect.reporter.firstName}} {{vmDefects.currentDefect.reporter.lastName}}
                                 <br>
                                 <b>Assigned to:</b>
                                 {{vmDefects.currentDefect.assignedTo}}
@@ -102,7 +102,9 @@
 
 
                                 <b>Description:</b>
+                                <span class="defectDescription">
                                 {{vmDefects.currentDefect.description}}
+                                </span>
                                 <br>
                                 <br>
                                 <b>Steps to reproduce:</b>

--- a/TCMSApp/src/client/app/defects/defects.module.js
+++ b/TCMSApp/src/client/app/defects/defects.module.js
@@ -4,7 +4,7 @@
     angular.module('app.defects', [
         'app.core',
         'app.widgets',
-        'ngResource'
+        'ngResource',
       ]);
 
 })();

--- a/TCMSApp/src/client/styles/styles.less
+++ b/TCMSApp/src/client/styles/styles.less
@@ -318,3 +318,13 @@ iframe {
 }
 
 //---------end landing styles---------//
+
+//Add defect page
+.errorMessageSpan{
+    color: @color_important;
+    display: block;
+    margin-top: 15px;
+}
+.defectDescription{
+    word-wrap: break-word;
+}

--- a/TCMSApp/src/server/model/mschemas/defect.js
+++ b/TCMSApp/src/server/model/mschemas/defect.js
@@ -1,22 +1,29 @@
 //import the necessary modules
 var mongoose = require('mongoose');
+var uniqueValidator = require('mongoose-unique-validator');
 var Schema = mongoose.Schema;
 
 //create  the defect model
 //define schema
 var defectSchema = new Schema({
-        name: {type: String, required: true, unique: true},
-        reporter: {type: mongoose.Schema.Types.ObjectId, required: true},
-        assignedTo: {type: mongoose.Schema.Types.ObjectId},
-        date: Date,
-        priority: {
-            type: String,
-            required: true,
-            enum: ['Critical', 'Low', 'High', 'Normal']
-        },
-        description: {type: String, required: true},
-        stepsToReproduce: [String],
-        run: {type: mongoose.Schema.Types.ObjectId}
-    });
-var defect = mongoose.model('Defect', defectSchema) ;
+    randomId: Number,
+    name: {type: String, required: true, unique: true},
+    reporter: {
+        type: mongoose.Schema.Types.ObjectId,
+        required: true,
+        ref: 'User'
+    },
+    assignedTo: {type: mongoose.Schema.Types.ObjectId},
+    dateOfDefectCreation: Date,
+    priority: {
+        type: String,
+        required: true,
+        enum: ['Critical', 'Low', 'High', 'Normal']
+    },
+    description: {type: String, required: true},
+    stepsToReproduce: [String],
+    run: {type: mongoose.Schema.Types.ObjectId}
+});
+defectSchema.plugin(uniqueValidator, {message: 'Error, expected {PATH} to be unique.'});
+var defect = mongoose.model('Defect', defectSchema);
 module.exports = defect;


### PR DESCRIPTION
fixed problem with Esc button, added current reporter. Added test for existing controller at defect page.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23issuecomment-179160966%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51718632%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51718740%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51719120%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51719180%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51720486%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51720927%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51728319%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51901452%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51901590%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r52022109%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r52022206%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r52022866%22%2C%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r52030243%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23issuecomment-179160966%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6055.12%25%60%5Cn%3E%20Merging%20%2A%2A%23198%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20increase%20coverage%20by%20%2A%2A%2B8.40%25%2A%2A%20as%20of%20%5B%6041af0f6%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23198%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2065%20%20%20%20%20%2070%20%20%20%20%20%2B5%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%201085%20%20%20%201326%20%20%20%2B241%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hit%20%20%20%20%20%20%20%20%20%20%20%20507%20%20%20%20%20731%20%20%20%2B224%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn-%20Missed%20%20%20%20%20%20%20%20%20578%20%20%20%20%20595%20%20%20%20%2B17%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%6041af0f6%60%5D%5B3%5D%5Cn%5Cn%5Cn-----%5Cn%23%23%23%20%5BUncovered%20Suggestions%5D%5B2%5D%5Cn%5Cn1.%20%60%2B1.29%25%60%20via%20%5B...defect.controller.js%2338...54%5D%28https%3A//codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/defects/add-defect.controller.js%3Fref%3D41af0f6d589df24bbdad39e8ddb471b1202aa608%2338%29%20%5Cn1.%20%60%2B1.29%25%60%20via%20%5B...ake-tests.factory.js%23115...131%5D%28https%3A//codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/blocks/fakers/fake-tests.factory.js%3Fref%3D41af0f6d589df24bbdad39e8ddb471b1202aa608%23115%29%20%5Cn1.%20%60%2B0.98%25%60%20via%20%5B...core/user.factory.js%2328...40%5D%28https%3A//codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/core/user.factory.js%3Fref%3D41af0f6d589df24bbdad39e8ddb471b1202aa608%2328%29%20%5Cn1.%20%2A%5BSee%207%20more...%5D%5B2%5D%2A%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012%3Fref%3D41af0f6d589df24bbdad39e8ddb471b1202aa608%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012/features/suggestions%3Fref%3D41af0f6d589df24bbdad39e8ddb471b1202aa608%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012/commit/41af0f6d589df24bbdad39e8ddb471b1202aa608%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/ITsvetkoFF/Kv-012/compare/98d1500b5a63bfdc0b61012cd921f9419b845f20...41af0f6d589df24bbdad39e8ddb471b1202aa608%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-02-03T10%3A51%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%207d280952859d4f0b999b61260aed82216d24ce2f%20TCMSApp/src/server/model/mschemas/defect.js%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51720927%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20field%20is%20optional%20and%20should%20be%20%60type%3A%20mongoose.Schema.Types.ObjectId%60%22%2C%20%22created_at%22%3A%20%222016-02-03T13%3A39%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16047947%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/AlexandraMart%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20have%20already%20type%3A%20mongoose.Schema.Types.ObjectId%20for%20run.%20Maybe%20it%27s%20the%20same%20as%20testRunId%22%2C%20%22created_at%22%3A%20%222016-02-03T14%3A41%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16047947%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/AlexandraMart%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/server/model/mschemas/defect.js%3AL1-25%22%7D%2C%20%22Pull%207d280952859d4f0b999b61260aed82216d24ce2f%20TCMSApp/src/client/app/defects/defects.controller.spec.js%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51719120%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20can%20write%20few%20more%20tests.%5Cr%5Cn1.%20check%20the%20fact%20that%20current%20project%20is%20set%5Cr%5Cn2.%20check%20the%20fact%20that%20if%20there%20are%20no%20projects%2C%20%60statusMessage%20%3D%20%27There%20are%20no%20defects%27%60%5Cr%5CnYou%27ve%20done%20almost%20all%20for%20that%20tests%20%28already%20mocked%20api%20call%29%22%2C%20%22created_at%22%3A%20%222016-02-03T13%3A20%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20yo%20wish%20to%20move%20somewhere%20from%20defects%2C%20it%20can%20be%20the%20separate%20task%20%28not%20for%20you%29%22%2C%20%22created_at%22%3A%20%222016-02-03T13%3A21%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20done%202%20more%20tests%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-05T14%3A37%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/defects/defects.controller.spec.js%3AL1-43%22%7D%2C%20%22Pull%203dd4575442b6f7e14c953e1d13e8fe2697b2d29a%20TCMSApp/src/client/app/defects/defects.module.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r52022109%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22not%20so%20useful%20change%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-02-05T14%3A36%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/defects/defects.module.js%3AL4-11%22%7D%2C%20%22Pull%203dd4575442b6f7e14c953e1d13e8fe2697b2d29a%20TCMSApp/src/client/app/defects/add-defect.controller.spec.js%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r52022866%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22the%20thing%20is%20that%20I%20don%27t%20see%20here%20any%20test%20of%20%5C%22Open%20Modal%5C%22.%20%5Cr%5CnYou%27re%20just%20declaring%20unused%20controllerModal%20and%20injecting%20%27%24uibModal%27.%20Or%20I%20can%20be%20wrong%3A%20but%20nevertheless%3A%20how%20%60Tests%20Add-Defects%20Open%20Model%60%20conceptually%20differs%20from%20%60Tests%20Defects%60%22%2C%20%22created_at%22%3A%20%222016-02-05T14%3A42%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%2C%20%7B%22body%22%3A%20%22Tests%20Add-Defects%20Open%20Model%20check%20succesful%20creation%20of%20controller%20AddDefectController%20and%20test%20defect%20-%20of%20controller%20Defect.%20Two%20controllers%2C%20two%20tests.%20Maybe%20Tests%20Add-Defects%20Open%20Model%20is%20not%20correct%20name%20of%20test%20-%20Test%20AddDefectController%20Open%20Model%20Branch%20will%20be%20better%22%2C%20%22created_at%22%3A%20%222016-02-05T15%3A38%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16047947%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/AlexandraMart%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/defects/add-defect.controller.spec.js%3AL1-55%22%7D%2C%20%22Pull%205a889d542bff9e84749958656c26a204cfdaf8ca%20TCMSApp/src/client/app/defects/add-defect.controller.spec.js%2095%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51901590%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%20if%20we%20will%20not%20pass%20useInfo%20to%20the%20controller%3F%22%2C%20%22created_at%22%3A%20%222016-02-04T16%3A54%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/defects/add-defect.controller.spec.js%3AL1-126%22%7D%2C%20%22Pull%207d280952859d4f0b999b61260aed82216d24ce2f%20TCMSApp/src/server/model/mschemas/defect.js%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51720486%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22that%20changes%20were%20good%22%2C%20%22created_at%22%3A%20%222016-02-03T13%3A34%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16047947%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/AlexandraMart%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/server/model/mschemas/defect.js%3AL1-25%22%7D%2C%20%22Pull%205a889d542bff9e84749958656c26a204cfdaf8ca%20TCMSApp/src/client/app/defects/add-defect.controller.spec.js%2063%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51901452%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Actually%20it%20is%20an%20example%20of%20code%20duplication%20%3A%29%20%5Cr%5CnTests%20are%20almost%20the%20same.%5Cr%5CnWhy%20do%20we%20need%20the%20second%20block%3F%20How%20it%20differs%20from%20the%20first%20one%3F%20Why%20do%20we%20pass%20%60uibModal%60%20and%20%60%24stateParams%3Astate%60%3F%22%2C%20%22created_at%22%3A%20%222016-02-04T16%3A53%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/defects/add-defect.controller.spec.js%3AL1-126%22%7D%2C%20%22Pull%207d280952859d4f0b999b61260aed82216d24ce2f%20TCMSApp/src/client/app/defects/defects.controller.spec.js%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51718740%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22we%20don%27t%20need%20such%20comments%29%22%2C%20%22created_at%22%3A%20%222016-02-03T13%3A17%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/defects/defects.controller.spec.js%3AL1-43%22%7D%2C%20%22Pull%207d280952859d4f0b999b61260aed82216d24ce2f%20TCMSApp/src/client/app/defects/add-defect.template.html%2079%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF/Kv-012/pull/198%23discussion_r51718632%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Let%27s%20do%20error%20message%20red%20and%20add%20some%20margin-top%22%2C%20%22created_at%22%3A%20%222016-02-03T13%3A16%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7273003%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ITsvetkoFF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20TCMSApp/src/client/app/defects/add-defect.template.html%3AL1-62%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#issuecomment-179160966'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `55.12%`
> Merging **#198** into **master** will increase coverage by **+8.40%** as of [`41af0f6`][3]
```diff
@@            master    #198   diff @@
======================================
Files           65      70     +5
Stmts         1085    1326   +241
Branches         0       0
Methods          0       0
======================================
+ Hit            507     731   +224
Partial          0       0
- Missed         578     595    +17
```
> Review entire [Coverage Diff][4] as of [`41af0f6`][3]
-----
### [Uncovered Suggestions][2]
1. `+1.29%` via [...defect.controller.js#38...54](https://codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/defects/add-defect.controller.js?ref=41af0f6d589df24bbdad39e8ddb471b1202aa608#38)
1. `+1.29%` via [...ake-tests.factory.js#115...131](https://codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/blocks/fakers/fake-tests.factory.js?ref=41af0f6d589df24bbdad39e8ddb471b1202aa608#115)
1. `+0.98%` via [...core/user.factory.js#28...40](https://codecov.io/github/ITsvetkoFF/Kv-012/src/client/app/core/user.factory.js?ref=41af0f6d589df24bbdad39e8ddb471b1202aa608#28)
1. *[See 7 more...][2]*
[1]: https://codecov.io/github/ITsvetkoFF/Kv-012?ref=41af0f6d589df24bbdad39e8ddb471b1202aa608
[2]: https://codecov.io/github/ITsvetkoFF/Kv-012/features/suggestions?ref=41af0f6d589df24bbdad39e8ddb471b1202aa608
[3]: https://codecov.io/github/ITsvetkoFF/Kv-012/commit/41af0f6d589df24bbdad39e8ddb471b1202aa608
[4]: https://codecov.io/github/ITsvetkoFF/Kv-012/compare/98d1500b5a63bfdc0b61012cd921f9419b845f20...41af0f6d589df24bbdad39e8ddb471b1202aa608
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- [ ] <a href='#crh-comment-Pull 7d280952859d4f0b999b61260aed82216d24ce2f TCMSApp/src/client/app/defects/add-defect.template.html 79'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#discussion_r51718632'>File: TCMSApp/src/client/app/defects/add-defect.template.html:L1-62</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> Let's do error message red and add some margin-top
- [ ] <a href='#crh-comment-Pull 7d280952859d4f0b999b61260aed82216d24ce2f TCMSApp/src/client/app/defects/defects.controller.spec.js 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#discussion_r51718740'>File: TCMSApp/src/client/app/defects/defects.controller.spec.js:L1-43</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> we don't need such comments)
- [ ] <a href='#crh-comment-Pull 7d280952859d4f0b999b61260aed82216d24ce2f TCMSApp/src/server/model/mschemas/defect.js 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#discussion_r51720486'>File: TCMSApp/src/server/model/mschemas/defect.js:L1-25</a></b>
- <a href='https://github.com/AlexandraMart'><img border=0 src='https://avatars.githubusercontent.com/u/16047947?v=3' height=16 width=16'></a> that changes were good
- [ ] <a href='#crh-comment-Pull 7d280952859d4f0b999b61260aed82216d24ce2f TCMSApp/src/server/model/mschemas/defect.js 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#discussion_r51720927'>File: TCMSApp/src/server/model/mschemas/defect.js:L1-25</a></b>
- <a href='https://github.com/AlexandraMart'><img border=0 src='https://avatars.githubusercontent.com/u/16047947?v=3' height=16 width=16'></a> this field is optional and should be `type: mongoose.Schema.Types.ObjectId`
- <a href='https://github.com/AlexandraMart'><img border=0 src='https://avatars.githubusercontent.com/u/16047947?v=3' height=16 width=16'></a> We have already type: mongoose.Schema.Types.ObjectId for run. Maybe it's the same as testRunId
- [ ] <a href='#crh-comment-Pull 5a889d542bff9e84749958656c26a204cfdaf8ca TCMSApp/src/client/app/defects/add-defect.controller.spec.js 63'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#discussion_r51901452'>File: TCMSApp/src/client/app/defects/add-defect.controller.spec.js:L1-126</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> Actually it is an example of code duplication :)
Tests are almost the same.
Why do we need the second block? How it differs from the first one? Why do we pass `uibModal` and `$stateParams:state`?
- [ ] <a href='#crh-comment-Pull 5a889d542bff9e84749958656c26a204cfdaf8ca TCMSApp/src/client/app/defects/add-defect.controller.spec.js 95'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#discussion_r51901590'>File: TCMSApp/src/client/app/defects/add-defect.controller.spec.js:L1-126</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> what if we will not pass useInfo to the controller?
- [ ] <a href='#crh-comment-Pull 3dd4575442b6f7e14c953e1d13e8fe2697b2d29a TCMSApp/src/client/app/defects/defects.module.js 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#discussion_r52022109'>File: TCMSApp/src/client/app/defects/defects.module.js:L4-11</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> not so useful change :)
- [ ] <a href='#crh-comment-Pull 3dd4575442b6f7e14c953e1d13e8fe2697b2d29a TCMSApp/src/client/app/defects/add-defect.controller.spec.js 2'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#discussion_r52022866'>File: TCMSApp/src/client/app/defects/add-defect.controller.spec.js:L1-55</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> the thing is that I don't see here any test of "Open Modal".
You're just declaring unused controllerModal and injecting '$uibModal'. Or I can be wrong: but nevertheless: how `Tests Add-Defects Open Model` conceptually differs from `Tests Defects`
- <a href='https://github.com/AlexandraMart'><img border=0 src='https://avatars.githubusercontent.com/u/16047947?v=3' height=16 width=16'></a> Tests Add-Defects Open Model check succesful creation of controller AddDefectController and test defect - of controller Defect. Two controllers, two tests. Maybe Tests Add-Defects Open Model is not correct name of test - Test AddDefectController Open Model Branch will be better
- [x] <a href='#crh-comment-Pull 7d280952859d4f0b999b61260aed82216d24ce2f TCMSApp/src/client/app/defects/defects.controller.spec.js 42'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ITsvetkoFF/Kv-012/pull/198#discussion_r51719120'>File: TCMSApp/src/client/app/defects/defects.controller.spec.js:L1-43</a></b>
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> you can write few more tests.
1. check the fact that current project is set
2. check the fact that if there are no projects, `statusMessage = 'There are no defects'`
You've done almost all for that tests (already mocked api call)
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> If yo wish to move somewhere from defects, it can be the separate task (not for you)
- <a href='https://github.com/ITsvetkoFF'><img border=0 src='https://avatars.githubusercontent.com/u/7273003?v=3' height=16 width=16'></a> Well done 2 more tests :+1:


<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/198?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ITsvetkoFF/Kv-012/pull/198?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ITsvetkoFF/Kv-012/pull/198'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>